### PR TITLE
Add support for existing blog posts

### DIFF
--- a/lib/school_house/content/post.ex
+++ b/lib/school_house/content/post.ex
@@ -1,0 +1,27 @@
+defmodule SchoolHouse.Content.Post do
+  @moduledoc """
+  The data representation of a post
+  """
+
+  @enforce_keys [:body, :name, :title]
+  defstruct [
+    :body,
+    :name,
+    :title
+  ]
+
+  def build(filename, attrs, body) do
+    [locale, section, name] =
+      filename
+      |> Path.rootname()
+      |> Path.split()
+      |> Enum.take(-3)
+
+    filename_attrs = [
+      body: body,
+      name: String.to_atom(name)
+    ]
+
+    struct!(__MODULE__, filename_attrs ++ Map.to_list(attrs))
+  end
+end

--- a/lib/school_house/posts.ex
+++ b/lib/school_house/posts.ex
@@ -1,0 +1,10 @@
+defmodule SchoolHouse.Posts do
+  @moduledoc """
+  Implements NimblePublisher and functions for retrieving blog posts
+  """
+  use NimblePublisher,
+    build: SchoolHouse.Content.Post,
+    from: "posts/*.md",
+    as: :lessons,
+    highlighters: [:makeup_elixir, :makeup_erlang]
+end


### PR DESCRIPTION
Need to update the `elixirschool/elixirschool` branch to include `_posts` and update the instructions to link those along with lessons in the top level.