### PR TITLE
configures production as explained in guides for Heroku

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -11,7 +11,7 @@ use Mix.Config
 # before starting your production server.
 config :school_house, SchoolHouseWeb.Endpoint,
   http: [port: {:system, "PORT"}],
-  url: [scheme: "https", host: "beta.elixirschool.com", port: 443]
+  url: [scheme: "https", host: "beta.elixirschool.com", port: 443],
   cache_static_manifest: "priv/static/cache_manifest.json"
 
 # Do not print debug messages in production

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -11,8 +11,7 @@ use Mix.Config
 # before starting your production server.
 config :school_house, SchoolHouseWeb.Endpoint,
   http: [port: {:system, "PORT"}],
-  url: [scheme: "https", host: "beta.elixir.com", port: 443],
-  force_ssl: [rewrite_on: [:x_forwarded_proto]],
+  url: [scheme: "https", host: "beta.elixirschool.com", port: 443]
   cache_static_manifest: "priv/static/cache_manifest.json"
 
 # Do not print debug messages in production

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -10,7 +10,9 @@ use Mix.Config
 # which you should run after static files are built and
 # before starting your production server.
 config :school_house, SchoolHouseWeb.Endpoint,
-  url: [host: "example.com", port: 80],
+  http: [port: {:system, "PORT"}],
+  url: [scheme: "https", host: "beta.elixir.com", port: 443],
+  force_ssl: [rewrite_on: [:x_forwarded_proto]],
   cache_static_manifest: "priv/static/cache_manifest.json"
 
 # Do not print debug messages in production


### PR DESCRIPTION
Hi! Related to https://github.com/elixirschool/school_house/issues/22 I think I've found the cause, it looks like `config/prod.exs` needed some attention as per [this guide](https://hexdocs.pm/phoenix/heroku.html#making-our-project-ready-for-heroku).