### PR TITLE
fixes HTML structure on lesson menu

### DIFF
--- a/lib/school_house_web/templates/layout/_lesson_menu.html.leex
+++ b/lib/school_house_web/templates/layout/_lesson_menu.html.leex
@@ -2,287 +2,343 @@
 <label for="toggle-one" class="block cursor-pointer py-6 px-4 lg:p-6 text-sm lg:text-base font-bold">Lessons</label>
 <div role="toggle" class="border-t-4 border-brand-purple p-6 mega-menu mb-16 sm:mb-0 shadow-xl bg-brand-light-gray">
     <div class="container mx-auto w-full flex flex-wrap justify-left mx-2 text-brand-gray">
-    <ul class="px-4 w-full sm:w-1/4 lg:w-1/5 border-gray-600 border-b sm:border-r lg:border-b-0 pb-6 pt-6 lg:pt-3">
-        <h3 class="font-bold text-xl text-brand-gray text-bold mb-2"><%= gettext("Basics") %></h3>
-        <li>
-        <%= lesson_link @conn, :basics, :basics do %>
-            1. <%= gettext("Basics") %>
-        <% end %>
-        </li>
-        <li>
-        <%= lesson_link @conn, :basics, :collections do %>
-            2. <%= gettext("Collections") %>
-        <% end %>
-        </li>
-        <li>
-        <%= lesson_link @conn, :basics, :enum do %>
-            3. <%= gettext("Enum") %>
-        <% end %>
-        </li>
-        <li>
-        <%= lesson_link @conn, :basics, :pattern_matching do %>
-            4. <%= gettext("Pattern Matching") %>
-        <% end %>
-        </li>
-        <li>
-        <%= lesson_link @conn, :basics, :control_structures do %>
-            5. <%= gettext("Control Structures") %>
-        <% end %>
-        </li>
-        <li>
-        <%= lesson_link @conn, :basics, :functions do %>
-            6. <%= gettext("Functions") %>
-        <% end %>
-        </li>
-        <li>
-        <%= lesson_link @conn, :basics, :pipe_operator do %>
-            7. <%= gettext("Pipe Operator") %>
-        <% end %>
-        </li>
-        <li>
-        <%= lesson_link @conn, :basics, :modules do %>
-            8. <%= gettext("Modules") %>
-        <% end %>
-        </li>
-        <li>
-        <%= lesson_link @conn, :basics, :mix do %>
-            9. <%= gettext("Mix") %>
-        <% end %>
-        </li>
-        <li>
-        <%= lesson_link @conn, :basics, :sigils do %>
-            10. <%= gettext("Sigils") %>
-        <% end %>
-        </li>
-        <li>
-        <%= lesson_link @conn, :basics, :documentation do %>
-            11. <%= gettext("Documentation") %>
-        <% end %>
-        </li>
-        <li>
-        <%= lesson_link @conn, :basics, :comprehensions do %>
-            12. <%= gettext("Comprehensions") %>
-        <% end %>
-        </li>
-        <li>
-        <%= lesson_link @conn, :basics, :strings do %>
-            13. <%= gettext("Strings") %>
-        <% end %>
-        </li>
-        <li>
-        <%= lesson_link @conn, :basics, :date_time do %>
-            14. <%= gettext("Date and Time") %>
-        <% end %>
-        </li>
-        <li>
-        <%= lesson_link @conn, :basics, :iex_helpers do %>
-            15. <%= gettext("IEX Helpers") %>
-        <% end %>
-        </li>
-    </ul>
-    <ul class="px-4 w-full sm:w-1/4 lg:w-1/5 border-gray-600 border-b sm:border-r lg:border-b-0 pb-6 pt-6 lg:pt-3">
-        <h3 class="font-bold text-xl text-brand-gray text-bold mb-2"><%= gettext("Intermediate") %></h3>
-        <li>
-        <%= lesson_link @conn, :intermediate, :mix_tasks do %>
-            1. <%= gettext("Custom Mix Tasks") %>
-        <% end %>
-        </li>
-        <li>
-        <%= lesson_link @conn, :intermediate, :erlang do %>
-            2. <%= gettext("Erlang Interoperability") %>
-        <% end %>
-        </li>
-        <li>
-        <%= lesson_link @conn, :intermediate, :error_handling do %>
-            3. <%= gettext("Error Handling") %>
-        <% end %>
-        </li>
-        <li>
-        <%= lesson_link @conn, :intermediate, :escripts do %>
-            3. <%= gettext("Executables") %>
-        <% end %>
-        </li>
-        <li>
-        <%= lesson_link @conn, :intermediate, :concurrency do %>
-            4. <%= gettext("Concurrency") %>
-        <% end %>
-        </li>
-        <h3 class="font-bold text-xl text-brand-gray text-bold mb-2 pt-6"><%= gettext("Advanced") %></h3>
-        <li>
-        <%= lesson_link @conn, :advanced, :otp_concurrency do %>
-            1. <%= gettext("OTP Concurrency") %><% end %>
-    </li>
-    <li>
-        <%= lesson_link @conn, :advanced, :otp_supervisors do %>
-        2. <%= gettext("OTP Supervisors") %>
-        <% end %>
-    </li>
-    <li>
-        <%= lesson_link @conn, :advanced, :otp_distribution do %>
-        3. <%= gettext("OTP Distribution") %>
-        <% end %>
-    </li>
-    <li>
-        <%= lesson_link @conn, :advanced, :mtaprogramming do %>
-        4. <%= gettext("Metaprogramming") %>
-        <% end %>
-    </li>
-    <li>
-        <%= lesson_link @conn, :advanced, :umbrella_projects do %>
-        5. <%= gettext("Umbrella Projects") %>
-        <% end %>
-    </li>
-    <li>
-        <%= lesson_link @conn, :advanced, :typespecs do %>
-        6. <%= gettext("Specifications and types") %>
-        <% end %>
-    </li>
-    <li>
-        <%= lesson_link @conn, :advanced, :behaviours do %>
-        7. <%= gettext("Behaviours") %>
-        <% end %>
-    </li>
-    <li>
-        <%= lesson_link @conn, :advanced, :protocols do %>
-        8. <%= gettext("Protocols") %>
-        <% end %>
-    </li>
-    </ul>
-    <ul class="px-4 w-full sm:w-1/4 lg:w-1/5 border-gray-600 border-b sm:border-r lg:border-b-0 pb-6 pt-6 lg:pt-3">
-        <h3 class="font-bold text-xl text-brand-gray text-bold mb-2"><%= gettext("Testing") %></h3>
-        <li>
-        <%= lesson_link @conn, :testing, :basics do %>
-            1. <%= gettext("Basics") %>
-        <% end %>
-        </li>
-        <li>
-        <%= lesson_link @conn, :testing, :doctests do %>
-            2. <%= gettext("Doctests") %>
-        <% end %>
-        </li>
-        <li>
-        <%= lesson_link @conn, :testing, :bypass do %>
-            3. Bypass <span class="text-xs italic"><%= gettext("library") %></span>
-        <% end %>
-        </li>
-        <li>
-        <%= lesson_link @conn, :testing, :mox do %>
-            4. Mox <span class="text-xs italic"><%= gettext("library") %></span>
-        <% end %>
-        </li>
-        <li>
-        <%= lesson_link @conn, :testing, :stream_data do %>
-            5. StreamData <span class="text-xs italic"><%= gettext("library") %></span>
-        <% end %>
-        </li>
-        <h3 class="font-bold text-xl text-brand-gray text-bold mb-2 pt-6"><%= gettext("Data Processing") %></h3>
-        <li>
-        <%= lesson_link @conn, :data_processing, :genstage do %>
-            1. GenStage <span class="text-xs italic"><%= gettext("library") %></span>
-        <% end %>
-        </li>
-        <li>
-        <%= lesson_link @conn, :data_processing, :flow do %>
-            2. Flow <span class="text-xs italic"><%= gettext("library") %></span>
-        <% end %>
-        </li>
-        <li>
-        <%= lesson_link @conn, :data_processing, :broadway do %>
-            2. Broadway <span class="text-xs italic"><%= gettext("library") %></span>
-        <% end %>
-        </li>
-    </ul>
 
-    <ul class="px-4 w-full sm:w-1/4 lg:w-1/5 border-gray-600 border-b sm:border-r lg:border-b-0 pb-6 pt-6 lg:pt-3">
-        <h3 class="font-bold text-xl text-brand-gray text-bold mb-2"><%= gettext("Ecto") %></h3>
-        <li>
-        <%= lesson_link @conn, :ecto, :introduction do %>
-            1. <%= gettext("Introduction") %>
-        <% end %>
-        </li>
-        <li>
-        <%= lesson_link @conn, :ecto, :changesets do %>
-            2. <%= gettext("Changesets") %><% end %>
-    </li>
-    <li>
-        <%= lesson_link @conn, :ecto, :associations do %>
-        3. <%= gettext("Associations") %>
-        <% end %>
-    </li>
-    <li>
-        <%= lesson_link @conn, :ecto, :querying_basics do %>
-        4. <%= gettext("Querying: Basics") %>
-        <% end %>
-    </li>
-    <li>
-        <%= lesson_link @conn, :ecto, :querying_advanced do %>
-        5. <%= gettext("Querying: Advanced") %>
-        <% end %>
-    </li>
-    <h3 class="font-bold text-xl text-brand-gray text-bold mb-2 pt-6"><%= gettext("Storage") %></h3>
-    <li>
-        <%= lesson_link @conn, :storage, :ets do %>
-        1. Erlang Term Storage (ETS)
-        <% end %>
-    </li>
-    <li>
-        <%= lesson_link @conn, :storage, :mnesia do %>
-        2. Mnesia
-        <% end %>
-    </li>
-    <li>
-        <%= lesson_link @conn, :storage, :cachex do %>
-        3. Cachex <span class="text-xs italic"><%= gettext("library") %></span>
-        <% end %>
-    </li>
-    <li>
-        <%= lesson_link @conn, :storage, :redix do %>
-        4. Redix <span class="text-xs italic"><%= gettext("library") %></span>
-        <% end %>
-    </li>
-    </ul>
-    <ul class="px-4 w-full sm:w-1/4 lg:w-1/5 border-gray-600 pb-6 pt-6 lg:pt-3">
-        <h3 class="font-bold text-xl text-brand-gray text-bold mb-2"><%= gettext("Miscellaneous") %></h3>
-        <li>
-        <%= lesson_link @conn, :misc, :plug do %>
-            1. Plug <span class="text-xs italic"><%= gettext("library") %></span>
-        <% end %>
-        </li>
-        <li>
-        <%= lesson_link @conn, :misc, :eex do %>
-            2. Embedded Elixir (EEx)
-        <% end %>
-        </li>
-        <li>
-        <%= lesson_link @conn, :misc, :debugging do %>
-            3. Debugging
-        <% end %>
-        </li>
-        <li>
-        <%= lesson_link @conn, :misc, :nerves do %>
-            4. Nerves <span class="text-xs italic"><%= gettext("library") %></span>
-        <% end %>
-        </li>
-        <li>
-        <%= lesson_link @conn, :misc, :guardian do %>
-            5. Guardian <span class="text-xs italic"><%= gettext("library") %></span>
-        <% end %>
-        </li>
-        <li>
-        <%= lesson_link @conn, :misc, :poolboy do %>
-            6. Poolboy <span class="text-xs italic"><%= gettext("library") %></span>
-        <% end %>
-        </li>
-        <li>
-        <%= lesson_link @conn, :misc, :distillery do %>
-            7. Distillery <span class="text-xs italic"><%= gettext("library") %></span>
-        <% end %>
-        </li>
-        <li>
-        <%= lesson_link @conn, :misc, :nimble_publisher do %>
-            8. NimblePublisher <span class="text-xs italic"><%= gettext("library") %></span>
-        <% end %>
-        </li>
-    </ul>
+        <!-- First column -->
+        <ul class="px-4 w-full sm:w-1/4 lg:w-1/5 border-gray-600 border-b sm:border-r lg:border-b-0 pb-6 pt-6 lg:pt-3">
+            <!-- Basics -->
+            <li>
+                <p class="font-bold text-xl text-brand-gray text-bold mb-2"><%= gettext("Basics") %></p>
+                <ul>
+                    <li>
+                        <%= lesson_link @conn, :basics, :basics do %>
+                            1. <%= gettext("Basics") %>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :basics, :collections do %>
+                            2. <%= gettext("Collections") %>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :basics, :enum do %>
+                            3. <%= gettext("Enum") %>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :basics, :pattern_matching do %>
+                            4. <%= gettext("Pattern Matching") %>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :basics, :control_structures do %>
+                            5. <%= gettext("Control Structures") %>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :basics, :functions do %>
+                            6. <%= gettext("Functions") %>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :basics, :pipe_operator do %>
+                            7. <%= gettext("Pipe Operator") %>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :basics, :modules do %>
+                            8. <%= gettext("Modules") %>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :basics, :mix do %>
+                            9. <%= gettext("Mix") %>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :basics, :sigils do %>
+                            10. <%= gettext("Sigils") %>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :basics, :documentation do %>
+                            11. <%= gettext("Documentation") %>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :basics, :comprehensions do %>
+                            12. <%= gettext("Comprehensions") %>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :basics, :strings do %>
+                            13. <%= gettext("Strings") %>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :basics, :date_time do %>
+                            14. <%= gettext("Date and Time") %>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :basics, :iex_helpers do %>
+                            15. <%= gettext("IEX Helpers") %>
+                        <% end %>
+                    </li>
+                </ul>
+            </li>
+
+        </ul>
+
+        <!-- Second column -->
+        <ul class="px-4 w-full sm:w-1/4 lg:w-1/5 border-gray-600 border-b sm:border-r lg:border-b-0 pb-6 pt-6 lg:pt-3">
+            <!-- Intermediate -->
+            <li>
+                <p class="font-bold text-xl text-brand-gray text-bold mb-2"><%= gettext("Intermediate") %></p>
+                <ul>
+                    <li>
+                        <%= lesson_link @conn, :intermediate, :mix_tasks do %>
+                            1. <%= gettext("Custom Mix Tasks") %>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :intermediate, :erlang do %>
+                            2. <%= gettext("Erlang Interoperability") %>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :intermediate, :error_handling do %>
+                            3. <%= gettext("Error Handling") %>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :intermediate, :escripts do %>
+                            3. <%= gettext("Executables") %>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :intermediate, :concurrency do %>
+                            4. <%= gettext("Concurrency") %>
+                        <% end %>
+                    </li>
+                </ul>
+            </li>
+
+            <!-- Advanced -->
+            <li>
+                <p class="font-bold text-xl text-brand-gray text-bold mb-2 pt-6"><%= gettext("Advanced") %></p>
+                <ul>
+                    <li>
+                        <%= lesson_link @conn, :advanced, :otp_concurrency do %>
+                            1. <%= gettext("OTP Concurrency") %>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :advanced, :otp_supervisors do %>
+                            2. <%= gettext("OTP Supervisors") %>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :advanced, :otp_distribution do %>
+                            3. <%= gettext("OTP Distribution") %>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :advanced, :mtaprogramming do %>
+                            4. <%= gettext("Metaprogramming") %>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :advanced, :umbrella_projects do %>
+                            5. <%= gettext("Umbrella Projects") %>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :advanced, :typespecs do %>
+                            6. <%= gettext("Specifications and types") %>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :advanced, :behaviours do %>
+                            7. <%= gettext("Behaviours") %>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :advanced, :protocols do %>
+                            8. <%= gettext("Protocols") %>
+                        <% end %>
+                    </li>
+                </ul>
+            </li>
+        </ul>
+
+        <!-- Third column -->
+        <ul class="px-4 w-full sm:w-1/4 lg:w-1/5 border-gray-600 border-b sm:border-r lg:border-b-0 pb-6 pt-6 lg:pt-3">
+            <!-- Testing -->
+            <li>
+                <p class="font-bold text-xl text-brand-gray text-bold mb-2"><%= gettext("Testing") %></p>
+                <ul>
+                    <li>
+                        <%= lesson_link @conn, :testing, :basics do %>
+                            1. <%= gettext("Basics") %>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :testing, :doctests do %>
+                            2. <%= gettext("Doctests") %>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :testing, :bypass do %>
+                            3. Bypass <span class="text-xs italic"><%= gettext("library") %></span>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :testing, :mox do %>
+                            4. Mox <span class="text-xs italic"><%= gettext("library") %></span>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :testing, :stream_data do %>
+                            5. StreamData <span class="text-xs italic"><%= gettext("library") %></span>
+                        <% end %>
+                    </li>
+                </ul>
+
+            </li>
+
+            <!-- Date Processing -->
+            <li>
+                <p class="font-bold text-xl text-brand-gray text-bold mb-2 pt-6"><%= gettext("Data Processing") %></p>
+                <ul>
+                    <li>
+                        <%= lesson_link @conn, :data_processing, :genstage do %>
+                            1. GenStage <span class="text-xs italic"><%= gettext("library") %></span>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :data_processing, :flow do %>
+                            2. Flow <span class="text-xs italic"><%= gettext("library") %></span>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :data_processing, :broadway do %>
+                            2. Broadway <span class="text-xs italic"><%= gettext("library") %></span>
+                        <% end %>
+                    </li>
+                </ul>
+            </li>
+        </ul>
+
+        <!-- Fourth column -->
+        <ul class="px-4 w-full sm:w-1/4 lg:w-1/5 border-gray-600 border-b sm:border-r lg:border-b-0 pb-6 pt-6 lg:pt-3">
+            <!-- Ecto -->
+            <li>
+                <p class="font-bold text-xl text-brand-gray text-bold mb-2"><%= gettext("Ecto") %></p>
+                <ul>
+                    <li>
+                        <%= lesson_link @conn, :ecto, :introduction do %>
+                            1. <%= gettext("Introduction") %>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :ecto, :changesets do %>
+                            2. <%= gettext("Changesets") %>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :ecto, :associations do %>
+                            3. <%= gettext("Associations") %>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :ecto, :querying_basics do %>
+                            4. <%= gettext("Querying: Basics") %>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :ecto, :querying_advanced do %>
+                            5. <%= gettext("Querying: Advanced") %>
+                        <% end %>
+                    </li>
+                </ul>
+            </li>
+
+            <!-- Storage -->
+            <li>
+                <p class="font-bold text-xl text-brand-gray text-bold mb-2 pt-6"><%= gettext("Storage") %></p>
+                <ul>
+                    <li>
+                        <%= lesson_link @conn, :storage, :ets do %>
+                        1. Erlang Term Storage (ETS)
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :storage, :mnesia do %>
+                        2. Mnesia
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :storage, :cachex do %>
+                        3. Cachex <span class="text-xs italic"><%= gettext("library") %></span>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :storage, :redix do %>
+                        4. Redix <span class="text-xs italic"><%= gettext("library") %></span>
+                        <% end %>
+                    </li>
+                </ul>
+            </li>
+        </ul>
+
+        <!-- Fifth column -->
+        <ul class="px-4 w-full sm:w-1/4 lg:w-1/5 border-gray-600 border-b sm:border-r lg:border-b-0 pb-6 pt-6 lg:pt-3">
+            <!-- Miscellaneous -->
+            <li>
+                <p class="font-bold text-xl text-brand-gray text-bold mb-2"><%= gettext("Miscellaneous") %></p>
+                <ul>
+                    <li>
+                        <%= lesson_link @conn, :misc, :plug do %>
+                            1. Plug <span class="text-xs italic"><%= gettext("library") %></span>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :misc, :eex do %>
+                            2. Embedded Elixir (EEx)
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :misc, :debugging do %>
+                            3. Debugging
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :misc, :nerves do %>
+                            4. Nerves <span class="text-xs italic"><%= gettext("library") %></span>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :misc, :guardian do %>
+                            5. Guardian <span class="text-xs italic"><%= gettext("library") %></span>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :misc, :poolboy do %>
+                            6. Poolboy <span class="text-xs italic"><%= gettext("library") %></span>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :misc, :distillery do %>
+                            7. Distillery <span class="text-xs italic"><%= gettext("library") %></span>
+                        <% end %>
+                    </li>
+                    <li>
+                        <%= lesson_link @conn, :misc, :nimble_publisher do %>
+                            8. NimblePublisher <span class="text-xs italic"><%= gettext("library") %></span>
+                        <% end %>
+                    </li>
+                </ul>
+            </li>
+        </ul>
     </div>
 </div>

--- a/lib/school_house_web/templates/layout/_lesson_menu.html.leex
+++ b/lib/school_house_web/templates/layout/_lesson_menu.html.leex
@@ -8,83 +8,83 @@
             <!-- Basics -->
             <li>
                 <p class="font-bold text-xl text-brand-gray text-bold mb-2"><%= gettext("Basics") %></p>
-                <ul>
+                <ol class="list-decimal ml-6">
                     <li>
                         <%= lesson_link @conn, :basics, :basics do %>
-                            1. <%= gettext("Basics") %>
+                            <%= gettext("Basics") %>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :basics, :collections do %>
-                            2. <%= gettext("Collections") %>
+                            <%= gettext("Collections") %>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :basics, :enum do %>
-                            3. <%= gettext("Enum") %>
+                            <%= gettext("Enum") %>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :basics, :pattern_matching do %>
-                            4. <%= gettext("Pattern Matching") %>
+                            <%= gettext("Pattern Matching") %>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :basics, :control_structures do %>
-                            5. <%= gettext("Control Structures") %>
+                            <%= gettext("Control Structures") %>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :basics, :functions do %>
-                            6. <%= gettext("Functions") %>
+                            <%= gettext("Functions") %>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :basics, :pipe_operator do %>
-                            7. <%= gettext("Pipe Operator") %>
+                            <%= gettext("Pipe Operator") %>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :basics, :modules do %>
-                            8. <%= gettext("Modules") %>
+                            <%= gettext("Modules") %>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :basics, :mix do %>
-                            9. <%= gettext("Mix") %>
+                            <%= gettext("Mix") %>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :basics, :sigils do %>
-                            10. <%= gettext("Sigils") %>
+                            <%= gettext("Sigils") %>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :basics, :documentation do %>
-                            11. <%= gettext("Documentation") %>
+                            <%= gettext("Documentation") %>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :basics, :comprehensions do %>
-                            12. <%= gettext("Comprehensions") %>
+                            <%= gettext("Comprehensions") %>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :basics, :strings do %>
-                            13. <%= gettext("Strings") %>
+                            <%= gettext("Strings") %>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :basics, :date_time do %>
-                            14. <%= gettext("Date and Time") %>
+                            <%= gettext("Date and Time") %>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :basics, :iex_helpers do %>
-                            15. <%= gettext("IEX Helpers") %>
+                            <%= gettext("IEX Helpers") %>
                         <% end %>
                     </li>
-                </ul>
+                </ol>
             </li>
 
         </ul>
@@ -94,80 +94,80 @@
             <!-- Intermediate -->
             <li>
                 <p class="font-bold text-xl text-brand-gray text-bold mb-2"><%= gettext("Intermediate") %></p>
-                <ul>
+                <ol class="list-decimal ml-6">
                     <li>
                         <%= lesson_link @conn, :intermediate, :mix_tasks do %>
-                            1. <%= gettext("Custom Mix Tasks") %>
+                            <%= gettext("Custom Mix Tasks") %>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :intermediate, :erlang do %>
-                            2. <%= gettext("Erlang Interoperability") %>
+                            <%= gettext("Erlang Interoperability") %>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :intermediate, :error_handling do %>
-                            3. <%= gettext("Error Handling") %>
+                            <%= gettext("Error Handling") %>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :intermediate, :escripts do %>
-                            3. <%= gettext("Executables") %>
+                            <%= gettext("Executables") %>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :intermediate, :concurrency do %>
-                            4. <%= gettext("Concurrency") %>
+                            <%= gettext("Concurrency") %>
                         <% end %>
                     </li>
-                </ul>
+                </ol>
             </li>
 
             <!-- Advanced -->
             <li>
                 <p class="font-bold text-xl text-brand-gray text-bold mb-2 pt-6"><%= gettext("Advanced") %></p>
-                <ul>
+                <ol class="list-decimal ml-6">
                     <li>
                         <%= lesson_link @conn, :advanced, :otp_concurrency do %>
-                            1. <%= gettext("OTP Concurrency") %>
+                            <%= gettext("OTP Concurrency") %>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :advanced, :otp_supervisors do %>
-                            2. <%= gettext("OTP Supervisors") %>
+                            <%= gettext("OTP Supervisors") %>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :advanced, :otp_distribution do %>
-                            3. <%= gettext("OTP Distribution") %>
+                            <%= gettext("OTP Distribution") %>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :advanced, :mtaprogramming do %>
-                            4. <%= gettext("Metaprogramming") %>
+                            <%= gettext("Metaprogramming") %>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :advanced, :umbrella_projects do %>
-                            5. <%= gettext("Umbrella Projects") %>
+                            <%= gettext("Umbrella Projects") %>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :advanced, :typespecs do %>
-                            6. <%= gettext("Specifications and types") %>
+                            <%= gettext("Specifications and types") %>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :advanced, :behaviours do %>
-                            7. <%= gettext("Behaviours") %>
+                            <%= gettext("Behaviours") %>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :advanced, :protocols do %>
-                            8. <%= gettext("Protocols") %>
+                            <%= gettext("Protocols") %>
                         <% end %>
                     </li>
-                </ul>
+                </ol>
             </li>
         </ul>
 
@@ -176,56 +176,56 @@
             <!-- Testing -->
             <li>
                 <p class="font-bold text-xl text-brand-gray text-bold mb-2"><%= gettext("Testing") %></p>
-                <ul>
+                <ol class="list-decimal ml-6">
                     <li>
                         <%= lesson_link @conn, :testing, :basics do %>
-                            1. <%= gettext("Basics") %>
+                            <%= gettext("Basics") %>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :testing, :doctests do %>
-                            2. <%= gettext("Doctests") %>
+                            <%= gettext("Doctests") %>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :testing, :bypass do %>
-                            3. Bypass <span class="text-xs italic"><%= gettext("library") %></span>
+                            Bypass <span class="text-xs italic"><%= gettext("library") %></span>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :testing, :mox do %>
-                            4. Mox <span class="text-xs italic"><%= gettext("library") %></span>
+                            Mox <span class="text-xs italic"><%= gettext("library") %></span>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :testing, :stream_data do %>
-                            5. StreamData <span class="text-xs italic"><%= gettext("library") %></span>
+                            StreamData <span class="text-xs italic"><%= gettext("library") %></span>
                         <% end %>
                     </li>
-                </ul>
+                </ol>
 
             </li>
 
             <!-- Date Processing -->
             <li>
                 <p class="font-bold text-xl text-brand-gray text-bold mb-2 pt-6"><%= gettext("Data Processing") %></p>
-                <ul>
+                <ol class="list-decimal ml-6">
                     <li>
                         <%= lesson_link @conn, :data_processing, :genstage do %>
-                            1. GenStage <span class="text-xs italic"><%= gettext("library") %></span>
+                            GenStage <span class="text-xs italic"><%= gettext("library") %></span>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :data_processing, :flow do %>
-                            2. Flow <span class="text-xs italic"><%= gettext("library") %></span>
+                            Flow <span class="text-xs italic"><%= gettext("library") %></span>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :data_processing, :broadway do %>
-                            2. Broadway <span class="text-xs italic"><%= gettext("library") %></span>
+                            Broadway <span class="text-xs italic"><%= gettext("library") %></span>
                         <% end %>
                     </li>
-                </ul>
+                </ol>
             </li>
         </ul>
 
@@ -234,60 +234,60 @@
             <!-- Ecto -->
             <li>
                 <p class="font-bold text-xl text-brand-gray text-bold mb-2"><%= gettext("Ecto") %></p>
-                <ul>
+                <ol class="list-decimal ml-6">
                     <li>
                         <%= lesson_link @conn, :ecto, :introduction do %>
-                            1. <%= gettext("Introduction") %>
+                            <%= gettext("Introduction") %>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :ecto, :changesets do %>
-                            2. <%= gettext("Changesets") %>
+                            <%= gettext("Changesets") %>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :ecto, :associations do %>
-                            3. <%= gettext("Associations") %>
+                            <%= gettext("Associations") %>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :ecto, :querying_basics do %>
-                            4. <%= gettext("Querying: Basics") %>
+                            <%= gettext("Querying: Basics") %>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :ecto, :querying_advanced do %>
-                            5. <%= gettext("Querying: Advanced") %>
+                            <%= gettext("Querying: Advanced") %>
                         <% end %>
                     </li>
-                </ul>
+                </ol>
             </li>
 
             <!-- Storage -->
             <li>
                 <p class="font-bold text-xl text-brand-gray text-bold mb-2 pt-6"><%= gettext("Storage") %></p>
-                <ul>
+                <ol class="list-decimal ml-6">
                     <li>
                         <%= lesson_link @conn, :storage, :ets do %>
-                        1. Erlang Term Storage (ETS)
+                            Erlang Term Storage (ETS)
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :storage, :mnesia do %>
-                        2. Mnesia
+                            Mnesia
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :storage, :cachex do %>
-                        3. Cachex <span class="text-xs italic"><%= gettext("library") %></span>
+                            Cachex <span class="text-xs italic"><%= gettext("library") %></span>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :storage, :redix do %>
-                        4. Redix <span class="text-xs italic"><%= gettext("library") %></span>
+                            Redix <span class="text-xs italic"><%= gettext("library") %></span>
                         <% end %>
                     </li>
-                </ul>
+                </ol>
             </li>
         </ul>
 
@@ -296,48 +296,48 @@
             <!-- Miscellaneous -->
             <li>
                 <p class="font-bold text-xl text-brand-gray text-bold mb-2"><%= gettext("Miscellaneous") %></p>
-                <ul>
+                <ol class="list-decimal ml-6">
                     <li>
                         <%= lesson_link @conn, :misc, :plug do %>
-                            1. Plug <span class="text-xs italic"><%= gettext("library") %></span>
+                            Plug <span class="text-xs italic"><%= gettext("library") %></span>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :misc, :eex do %>
-                            2. Embedded Elixir (EEx)
+                            Embedded Elixir (EEx)
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :misc, :debugging do %>
-                            3. Debugging
+                            Debugging
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :misc, :nerves do %>
-                            4. Nerves <span class="text-xs italic"><%= gettext("library") %></span>
+                            Nerves <span class="text-xs italic"><%= gettext("library") %></span>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :misc, :guardian do %>
-                            5. Guardian <span class="text-xs italic"><%= gettext("library") %></span>
+                            Guardian <span class="text-xs italic"><%= gettext("library") %></span>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :misc, :poolboy do %>
-                            6. Poolboy <span class="text-xs italic"><%= gettext("library") %></span>
+                            Poolboy <span class="text-xs italic"><%= gettext("library") %></span>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :misc, :distillery do %>
-                            7. Distillery <span class="text-xs italic"><%= gettext("library") %></span>
+                            Distillery <span class="text-xs italic"><%= gettext("library") %></span>
                         <% end %>
                     </li>
                     <li>
                         <%= lesson_link @conn, :misc, :nimble_publisher do %>
-                            8. NimblePublisher <span class="text-xs italic"><%= gettext("library") %></span>
+                            NimblePublisher <span class="text-xs italic"><%= gettext("library") %></span>
                         <% end %>
                     </li>
-                </ul>
+                </ol>
             </li>
         </ul>
     </div>


### PR DESCRIPTION
This fixes this HTML issue on the lesson menu:

https://rocketvalidator.com/s/5a71bc62-29c6-4e85-9ce5-2af0513f1976/i/106525604

The problem was in this structure:

```html
<ul>
  <h3>Ecto</h3>
  <li>1.- Introduction</li>
  <li>2.- Changesets</li>
</ul>
```

This was invalid as an `<ul>` element expects only `<li>` elements as direct children.

Instead, I propose this structure using nested lists. I'm also using `<ol>` for the nested lists, as they're in fact _ordered lists_

```html
<ul>
  <li>
    <p>Ecto</p>
    <ol>
      <li>1.- Introduction</li>
      <li>2.- Changesets</li>
    </ol>
  </li>

  <li>
    <p>Storage</p>
    <ol>
      <li>1.- ETS</li>
      <li>2.- Mnesia</li>
    </ol>
  </li>
</ul>
```
