### PR TITLE
We only need to modify the path

### DIFF
--- a/lib/school_house_web/templates/layout/_locale_menu.html.leex
+++ b/lib/school_house_web/templates/layout/_locale_menu.html.leex
@@ -10,7 +10,7 @@
     <div x-show="isOpen" @click.away=" { isOpen = false } " class="origin-top-right absolute left-0 mt-2 w-24 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none" role="menu" aria-orientation="vertical" aria-labelledby="options-menu">
         <div class="py-1" role="none">
         <%= for locale <- supported_locales() do %>
-            <a href="<%= current_page_locale_link(@conn, locale) %>" class="block px-4 py-2 text-sm text-gray-700 hover:bg-brand-light-gray hover:font-bold" role="menuitem"><%= locale %></a>
+            <a href="<%= current_page_locale_path(@conn, locale) %>" class="block px-4 py-2 text-sm text-gray-700 hover:bg-brand-light-gray hover:font-bold" role="menuitem"><%= locale %></a>
         <% end %>
         </div>
     </div>

--- a/lib/school_house_web/views/html_helpers.ex
+++ b/lib/school_house_web/views/html_helpers.ex
@@ -9,9 +9,8 @@ defmodule SchoolHouseWeb.HtmlHelpers do
 
   def avatar_url(github_link), do: "#{github_link}.png"
 
-  def current_page_locale_link(conn, locale) do
-    current_url = Phoenix.Controller.current_url(conn)
-    String.replace(current_url, current_locale(), locale)
+  def current_page_locale_path(%{request_path: request_path}, locale) do
+    String.replace(request_path, current_locale(), locale, global: false)
   end
 
   def lesson_link(conn, section, name, do: contents) do

--- a/test/school_house_web/views/html_helpers_test.exs
+++ b/test/school_house_web/views/html_helpers_test.exs
@@ -1,0 +1,57 @@
+defmodule SchoolHouseWeb.HtmlHelpersTest do
+  use SchoolHouseWeb.ConnCase
+
+  alias SchoolHouseWeb.HtmlHelpers
+
+  describe "avatar_url/1" do
+    test "appends .png to GitHub profile link" do
+      assert "https://github.com/elixirschool.png" == HtmlHelpers.avatar_url("https://github.com/elixirschool")
+    end
+  end
+
+  describe "current_locale/0" do
+    setup do
+      Gettext.put_locale("es")
+
+      on_exit(fn ->
+        Gettext.put_locale("en")
+      end)
+    end
+
+    test "returns the current locale used by Gettext" do
+      assert "es" == HtmlHelpers.current_locale()
+    end
+  end
+
+  describe "current_page_locale_path/2" do
+    setup do
+      Gettext.put_locale("es")
+
+      on_exit(fn ->
+        Gettext.put_locale("en")
+      end)
+    end
+
+    test "returns the current page path for another locale" do
+      assert "/fr/ecto/changesets" ==
+               :get
+               |> build_conn("/es/ecto/changesets")
+               |> HtmlHelpers.current_page_locale_path("fr")
+
+      # With or without a leading slash, the replacement is correct
+      assert "fr/ecto/changesets" ==
+               :get
+               |> build_conn("es/ecto/changesets")
+               |> HtmlHelpers.current_page_locale_path("fr")
+    end
+  end
+
+  describe "supported_locales/0" do
+    test "returns a list of all supported locales" do
+      locales = HtmlHelpers.supported_locales()
+
+      assert is_list(locales)
+      assert 1 < length(locales)
+    end
+  end
+end

--- a/test/school_house_web/views/html_helpers_test.exs
+++ b/test/school_house_web/views/html_helpers_test.exs
@@ -3,6 +3,14 @@ defmodule SchoolHouseWeb.HtmlHelpersTest do
 
   alias SchoolHouseWeb.HtmlHelpers
 
+  setup do
+    Gettext.put_locale("es")
+
+    on_exit(fn ->
+      Gettext.put_locale("en")
+    end)
+  end
+
   describe "avatar_url/1" do
     test "appends .png to GitHub profile link" do
       assert "https://github.com/elixirschool.png" == HtmlHelpers.avatar_url("https://github.com/elixirschool")
@@ -10,28 +18,12 @@ defmodule SchoolHouseWeb.HtmlHelpersTest do
   end
 
   describe "current_locale/0" do
-    setup do
-      Gettext.put_locale("es")
-
-      on_exit(fn ->
-        Gettext.put_locale("en")
-      end)
-    end
-
     test "returns the current locale used by Gettext" do
       assert "es" == HtmlHelpers.current_locale()
     end
   end
 
   describe "current_page_locale_path/2" do
-    setup do
-      Gettext.put_locale("es")
-
-      on_exit(fn ->
-        Gettext.put_locale("en")
-      end)
-    end
-
     test "returns the current page path for another locale" do
       assert "/fr/ecto/changesets" ==
                :get


### PR DESCRIPTION
Update the function to `_url` from `_link` to more accurately reflect
what it does. Only modify the request path, the entire url is not
necessary. 

Fixes #22.