### PR TITLE
Update scroll to top link with an arrow

### DIFF
--- a/lib/school_house_web/templates/lesson/_section_header.html.eex
+++ b/lib/school_house_web/templates/lesson/_section_header.html.eex
@@ -1,4 +1,8 @@
-<<%= @header %> id="<%= @fragment %>">
+<<%= @header %> id="<%= @fragment %>" class="flex">
   <a href="#<%= @fragment %>"><%= @name %></a>
-  <a href="#" class="text-brand-gray font-xsmall">top of page</a>
+  <a href="#" title="go to top of page" class="ml-2 pt-1">
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7" />
+    </svg>
+  </a>
 </<%= @header %>>


### PR DESCRIPTION
Closes #11, this PR simply replaces the string "top of page" with an arrow. 
![image](https://user-images.githubusercontent.com/73517/114914908-c3984d80-9dd7-11eb-9d7b-62521a058ce5.png)