### PR TITLE
Correct invalid lesson name in configuration

### DIFF
--- a/config/lessons.exs
+++ b/config/lessons.exs
@@ -46,7 +46,7 @@ config :school_house,
       :stream_data
     ],
     data_processing: [
-      :gen_stage,
+      :genstage,
       :flow,
       :broadway
     ],


### PR DESCRIPTION
This is partially responsible for #26 but there is a greater bug there that needs addressing. This PR just corrects the misconfigured value.