### PR TITLE
Add a prev and next link to lessons template

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2,15 +2,6 @@
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
 
-.full-width {
-  width: 100vw;
-  position: relative;
-  left: 50%;
-  right: 50%;
-  margin-left: -50vw;
-  margin-right: -50vw;
-}
-
 /* ––––––––––––––––––––––––––––––––––––––––––––––––––
 Based on: https://codepen.io/nickelse/pen/YGPJQG
 Influenced by: https://sproutsocial.com/

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2,6 +2,15 @@
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
 
+.full-width {
+  width: 100vw;
+  position: relative;
+  left: 50%;
+  right: 50%;
+  margin-left: -50vw;
+  margin-right: -50vw;
+}
+
 /* ––––––––––––––––––––––––––––––––––––––––––––––––––
 Based on: https://codepen.io/nickelse/pen/YGPJQG
 Influenced by: https://sproutsocial.com/

--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -18,6 +18,9 @@ module.exports = {
             container: {
                 center: true,
             },
+            margin: {
+            'half-screen': '-50vw',
+            },
             typography: (theme) => ({
                 DEFAULT: {
                     css: {

--- a/lib/school_house_web/templates/lesson/_pagination.html.eex
+++ b/lib/school_house_web/templates/lesson/_pagination.html.eex
@@ -1,0 +1,54 @@
+<section class="bg-brand-light-gray -mb-16 mt-16 ml-half-screen mr-half-screen w-screen relative left-2/4 right-2/4">
+  <div class="max-w-7xl mx-auto py-8 px-4 sm:px-6 lg:py-12 lg:px-8 items-center">
+      <div class="flex md:justify-between flex-col-reverse md:flex-row">
+        <div class="md:w-1/3 mt-12 md:mt-0">
+          <%= if @previous do %>
+            <div class="flex md:justify-start justify-center items-center content-center mb-2">
+              <svg xmlns="http://www.w3.org/2000/svg" class="text-gray-400 h-6 w-6 mr-2 hidden md:block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+              </svg>
+              <h3 class="leading-tight text-sm font-semibold text-gray-400 tracking-wider uppercase">
+                <%= lesson_link(@conn, @previous.section, @previous.name, "hover:text-brand-gray") do %>
+                  Previous lesson
+                <% end %>
+              </h3>
+            </div>
+            <div class="text-center">
+              <p class="text-base font-semibold text-brand-gray mb-2">
+              <%= lesson_link(@conn, @previous.section, @previous.name, "hover:text-brand-gray") do %>
+                <%= @previous.title %>
+              <% end %>
+              </p>
+              <p class="md:text-left text-center text-sm text-gray-500 overflow-hidden max-h-16">
+                <%= raw @previous.excerpt %>
+              </p>
+            </div>
+          <% end %>
+        </div>
+        <div class="md:w-1/3">
+          <%= if @next do %>
+            <div class="flex md:justify-end justify-center items-center content-center mb-2">
+              <h3 class="leading-tight text-sm font-semibold text-gray-400 tracking-wider uppercase">
+                <%= lesson_link(@conn, @next.section, @next.name, "hover:text-brand-gray") do %>
+                  Next Lesson
+                <% end %>
+              </h3>
+              <svg xmlns="http://www.w3.org/2000/svg" class="text-gray-400 h-6 w-6 ml-2 hidden md:block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+              </svg>
+            </div>
+            <div class="text-center">
+              <p class="text-base font-semibold text-brand-gray mb-2">
+                <%= lesson_link(@conn, @next.section, @next.name, "hover:text-brand-gray") do %>
+                  <%= @next.title %>
+                <% end %>
+              </p>
+              <p class="text-italic md:text-left text-center text-sm text-gray-500 overflow-hidden max-h-16">
+                <%= raw @next.excerpt %>
+              </p>
+            </div>
+          <% end %>
+        </div>
+      </div>
+  </div>
+</section>

--- a/lib/school_house_web/templates/lesson/lesson.html.eex
+++ b/lib/school_house_web/templates/lesson/lesson.html.eex
@@ -13,10 +13,67 @@
   </div>
   <%= raw @lesson.body %>
 
-  <blockquote class="edit-lesson">    
+  <blockquote class="edit-lesson">
     Caught a mistake or want to contribute to the lesson?
     <a href="https://github.com/elixirschool/elixirschool/edit/master/<%= @lesson.locale %>/lessons/<%= @lesson.section %>/<%= @lesson.name %>.md" target="_blank" rel="noopener">
       Edit this lesson on GitHub!
     </a>
   </blockquote>
 </section>
+
+<section class="bg-brand-light-gray full-width -mb-16 mt-16">
+  <div class="max-w-7xl mx-auto py-8 px-4 sm:px-6 lg:py-12 lg:px-8 items-center">
+      <div class="flex md:justify-between flex-col-reverse md:flex-row">
+        <div class="md:w-1/3 mt-8 md:mt-0">
+          <%= if @lesson.previous do %>
+            <div class="flex md:justify-start justify-center items-center content-center mb-6">
+              <svg xmlns="http://www.w3.org/2000/svg" class="text-gray-400 h-6 w-6 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+              </svg>
+              <h3 class="leading-tight text-sm font-semibold text-gray-400 tracking-wider uppercase">
+                <a href="/<%= @lesson.previous.locale %>/<%= @lesson.previous.section %>/<%= @lesson.previous.name %>" class="hover:text-gray-900">
+                  Previous lesson
+                </a>
+              </h3>
+            </div>
+            <div class="text-center">
+              <p class="text-base font-semibold text-gray-900 mb-2">
+                <%= @lesson.previous.title %>
+              </p>
+              <p class="md:text-left text-center text-sm text-gray-500 overflow-hidden max-h-16">
+                <%= raw @lesson.previous.excerpt %>
+              </p>
+            </div>
+          <% end %>
+        </div>
+        <div class="md:w-1/3">
+          <%= if @lesson.next do %>
+            <div class="flex md:justify-end justify-center items-center content-center mb-6">
+              <h3 class="leading-tight text-sm font-semibold text-gray-400 tracking-wider uppercase">
+                <a href="/<%= @lesson.next.locale %>/<%= @lesson.next.section %>/<%= @lesson.next.name %>" class="hover:text-gray-900">
+                  Next lesson
+                </a>
+              </h3>
+              <svg xmlns="http://www.w3.org/2000/svg" class="text-gray-400 h-6 w-6 ml-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+              </svg>
+            </div>
+            <div class="text-center">
+              <p class="text-base font-semibold text-gray-900 mb-2">
+                <%= @lesson.next.title %>
+              </p>
+              <p class="text-italic md:text-left text-center text-sm text-gray-500 overflow-hidden max-h-16">
+                <%= raw @lesson.next.excerpt %>
+              </p>
+            </div>
+          <% end %>
+        </div>
+      </div>
+  </div>
+</section>
+
+<div class="relative -mb-16 pb-16">
+  <div class="absolute inset-0 flex items-center pt-16" aria-hidden="true">
+    <div class="w-full border-t border-gray-200"></div>
+  </div>
+</div>

--- a/lib/school_house_web/templates/lesson/lesson.html.eex
+++ b/lib/school_house_web/templates/lesson/lesson.html.eex
@@ -21,7 +21,7 @@
   </blockquote>
 </section>
 
-<section class="bg-brand-light-gray full-width -mb-16 mt-16">
+<section class="bg-brand-light-gray -mb-16 mt-16 w-screen relative left-2/4 right-2/4 ml-half-screen mr-half-screen">
   <div class="max-w-7xl mx-auto py-8 px-4 sm:px-6 lg:py-12 lg:px-8 items-center">
       <div class="flex md:justify-between flex-col-reverse md:flex-row">
         <div class="md:w-1/3 mt-8 md:mt-0">

--- a/lib/school_house_web/templates/lesson/lesson.html.eex
+++ b/lib/school_house_web/templates/lesson/lesson.html.eex
@@ -21,56 +21,7 @@
   </blockquote>
 </section>
 
-<section class="bg-brand-light-gray -mb-16 mt-16 w-screen relative left-2/4 right-2/4 ml-half-screen mr-half-screen">
-  <div class="max-w-7xl mx-auto py-8 px-4 sm:px-6 lg:py-12 lg:px-8 items-center">
-      <div class="flex md:justify-between flex-col-reverse md:flex-row">
-        <div class="md:w-1/3 mt-8 md:mt-0">
-          <%= if @lesson.previous do %>
-            <div class="flex md:justify-start justify-center items-center content-center mb-6">
-              <svg xmlns="http://www.w3.org/2000/svg" class="text-gray-400 h-6 w-6 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
-              </svg>
-              <h3 class="leading-tight text-sm font-semibold text-gray-400 tracking-wider uppercase">
-                <a href="/<%= @lesson.previous.locale %>/<%= @lesson.previous.section %>/<%= @lesson.previous.name %>" class="hover:text-gray-900" rel="prev">
-                  Previous lesson
-                </a>
-              </h3>
-            </div>
-            <div class="text-center">
-              <p class="text-base font-semibold text-gray-900 mb-2">
-                <%= @lesson.previous.title %>
-              </p>
-              <p class="md:text-left text-center text-sm text-gray-500 overflow-hidden max-h-16">
-                <%= raw @lesson.previous.excerpt %>
-              </p>
-            </div>
-          <% end %>
-        </div>
-        <div class="md:w-1/3">
-          <%= if @lesson.next do %>
-            <div class="flex md:justify-end justify-center items-center content-center mb-6">
-              <h3 class="leading-tight text-sm font-semibold text-gray-400 tracking-wider uppercase">
-                <a href="/<%= @lesson.next.locale %>/<%= @lesson.next.section %>/<%= @lesson.next.name %>" class="hover:text-gray-900" rel="next">
-                  Next lesson
-                </a>
-              </h3>
-              <svg xmlns="http://www.w3.org/2000/svg" class="text-gray-400 h-6 w-6 ml-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-              </svg>
-            </div>
-            <div class="text-center">
-              <p class="text-base font-semibold text-gray-900 mb-2">
-                <%= @lesson.next.title %>
-              </p>
-              <p class="text-italic md:text-left text-center text-sm text-gray-500 overflow-hidden max-h-16">
-                <%= raw @lesson.next.excerpt %>
-              </p>
-            </div>
-          <% end %>
-        </div>
-      </div>
-  </div>
-</section>
+<%= render("_pagination.html", conn: @conn, next: @lesson.next, previous: @lesson.previous) %>
 
 <div class="relative -mb-16 pb-16">
   <div class="absolute inset-0 flex items-center pt-16" aria-hidden="true">

--- a/lib/school_house_web/templates/lesson/lesson.html.eex
+++ b/lib/school_house_web/templates/lesson/lesson.html.eex
@@ -31,7 +31,7 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
               </svg>
               <h3 class="leading-tight text-sm font-semibold text-gray-400 tracking-wider uppercase">
-                <a href="/<%= @lesson.previous.locale %>/<%= @lesson.previous.section %>/<%= @lesson.previous.name %>" class="hover:text-gray-900">
+                <a href="/<%= @lesson.previous.locale %>/<%= @lesson.previous.section %>/<%= @lesson.previous.name %>" class="hover:text-gray-900" rel="prev">
                   Previous lesson
                 </a>
               </h3>
@@ -50,7 +50,7 @@
           <%= if @lesson.next do %>
             <div class="flex md:justify-end justify-center items-center content-center mb-6">
               <h3 class="leading-tight text-sm font-semibold text-gray-400 tracking-wider uppercase">
-                <a href="/<%= @lesson.next.locale %>/<%= @lesson.next.section %>/<%= @lesson.next.name %>" class="hover:text-gray-900">
+                <a href="/<%= @lesson.next.locale %>/<%= @lesson.next.section %>/<%= @lesson.next.name %>" class="hover:text-gray-900" rel="next">
                   Next lesson
                 </a>
               </h3>


### PR DESCRIPTION
This one closes #5 by adding a section to the footer for the next and previous lesson. 

![es-prevnext-mobile](https://user-images.githubusercontent.com/73517/116163719-237ed600-a6ad-11eb-9493-65de66675992.png)
![es-prevnext-full](https://user-images.githubusercontent.com/73517/116163721-25489980-a6ad-11eb-9cd6-140b1962d152.png)
