### PR TITLE
Show An Error Message When Blog Post Is Not Found [Closes #27]

### DIFF
--- a/lib/school_house_web/controllers/post_controller.ex
+++ b/lib/school_house_web/controllers/post_controller.ex
@@ -13,13 +13,8 @@ defmodule SchoolHouseWeb.PostController do
   end
 
   def show(conn, %{"slug" => slug}) do
-    case Posts.get(slug) do
-      %{} = post ->
-        render(conn, "post.html", post: post)
-
-      nil ->
-        nil
-    end
+    post = Posts.get(slug)
+    render(conn, "post.html", post: post)
   end
 
   defp current_page(params) do

--- a/lib/school_house_web/templates/post/post.html.eex
+++ b/lib/school_house_web/templates/post/post.html.eex
@@ -1,28 +1,38 @@
-<section class="container w-3/4 mb-6 items-center prose dark:prose-dark">
-  <div class="py-6 text-center">
-    <span class="text-4xl leading-8 font-extrabold tracking-tight text-purple dark:text-purple-dark sm:text-4xl ">Elixir School</span>
-  </div>
-
-  <div class="relative">
-    <div class="absolute inset-0 flex items-center" aria-hidden="true">
-      <div class="w-full border-t border-gray-300"></div>
+<section class="container w-3/4 mb-6 items-center">
+  <%= if @post do %>
+    <div class="py-6 text-center">
+      <span class="text-4xl leading-8 font-extrabold tracking-tight text-purple dark:text-purple-dark sm:text-4xl ">Elixir School</span>
     </div>
-    <div class="relative flex justify-center">
-      <span class="px-2 bg-white dark:bg-body-dark text-sm text-light dark:text-light-dark">
-        Presents
+
+    <div class="relative">
+      <div class="absolute inset-0 flex items-center" aria-hidden="true">
+        <div class="w-full border-t border-gray-300"></div>
+      </div>
+      <div class="relative flex justify-center">
+        <span class="px-2 bg-white dark:bg-body-dark text-sm text-light dark:text-light-dark">
+          Presents
+        </span>
+      </div>
+    </div>
+
+    <div class="pt-6 text-center">
+      <span class="text-2xl leading-8 font-extrabold tracking-tight text-primary dark:text-primary-dark sm:text-2xl"><%= @post.title %></span>
+    </div>
+
+    <div class="py-2 text-center">
+      <span class="text-medium leading-8 tracking-tight text-primary dark:text-primary-dark sm:text-large ">By <%= @post.author %></span>
+    </div>
+
+    <div class="bg-brand-gray-300 dark:bg-brand-gray-800 rounded-xl p-4 mb-3 text-xl text-light dark:text-light-dark sm:mb-4 text-center"><%= raw @post.excerpt %></div>
+
+    <div class="prose dark:prose-dark">
+      <%= raw @post.body %>
+    </div>
+  <% else %>
+    <div class="my-20 text-center">
+      <span class="text-2xl font-bold tracking-tight text-light dark:text-light-dark sm:text-2xl">
+        Sorry, we couldn&apos;t find the post you are looking for.
       </span>
     </div>
-  </div>
-
-  <div class="pt-6 text-center">
-    <span class="text-2xl leading-8 font-extrabold tracking-tight text-primary dark:text-primary-dark sm:text-2xl"><%= @post.title %></span>
-  </div>
-
-  <div class="py-2 text-center">
-    <span class="text-medium leading-8 tracking-tight text-primary dark:text-primary-dark sm:text-large ">By <%= @post.author %></span>
-  </div>
-
-  <div class="bg-brand-gray-300 dark:bg-brand-gray-800 rounded-xl p-4 mb-3 text-xl text-light dark:text-light-dark sm:mb-4 text-center"><%= raw @post.excerpt %></div>
-
-  <%= raw @post.body %>
+  <% end %>
 </section>

--- a/test/school_house_web/controllers/post_controller_test.exs
+++ b/test/school_house_web/controllers/post_controller_test.exs
@@ -18,5 +18,13 @@ defmodule SchoolHouseWeb.PostControllerTest do
       assert body =~ "Title for a post"
       assert body =~ "By Sean Callan"
     end
+
+    test "renders a page with an error message when the blog post is not found", %{conn: conn} do
+      conn = get(conn, Routes.post_path(conn, :show, "test_no_post_found"))
+      body = html_response(conn, 200)
+
+      assert body =~ "Sorry, we couldn&apos;t find the post you are looking for."
+      refute body =~ "By Sean Callan"
+    end
   end
 end


### PR DESCRIPTION
## Scope
This pr updates the post controller to return a `conn` even when the post is not found. The view now handles the case where the post assign is nil by displaying a user-friendly error message.

Closes #27.

### The Result

**Dark** 🌔 

![Dark](https://user-images.githubusercontent.com/1526888/120052237-7c5dc900-bfe1-11eb-90d3-f3051fe61da3.png)

**Light** ☀️

![Light](https://user-images.githubusercontent.com/1526888/120052238-7d8ef600-bfe1-11eb-933c-224d8a6b8ce9.png)
