### PR TITLE
Update Dockerfile to Resolve Deploy Issue

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-content/
 README.md
 test/
 .git/

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,14 +17,17 @@ ENV MIX_ENV=prod
 COPY mix.exs mix.lock ./
 COPY config config
 RUN mix do deps.get, deps.compile
-COPY lib lib
 
-# build assets
+# install npm dependencies
 COPY assets/package.json assets/package-lock.json ./assets/
 RUN npm --prefix ./assets ci --progress=false --no-audit --loglevel=error
 
+COPY lib lib
+COPY assets assets
 COPY priv priv
 
+# grab images
+COPY Makefile Makefile
 RUN make content
 
 RUN npm run --prefix ./assets deploy

--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,4 @@ setup: content
 
 content: 
 	git clone --branch content-only-changes --single-branch --depth 1 https://github.com/elixirschool/elixirschool.git content
-	ln -s content/images/* assets/static
+	mv content/images assets/static/images


### PR DESCRIPTION
## Overview

I updated the `Dockerfile`, `Makefile` and `.dockerignore` files to hopefully resolve GH actions failure (#66).

The primary reason that the build failed was that the `Makefile` was not found when `make content` was run. After that, I ran into issues trying to use a symlink for the image assets with docker. I ultimately settled on just `COPY`-ing the image assets.

I moved the symlink to the `make setup` command so users can still use it for their dev environment and the Dockerfile can still use `make content`.

Happy to play around with the Dockerfile if there a different preferred way to write this.