### PR TITLE
Update Colors And Dark Mode Toggle to Improve A11Y

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -89,7 +89,7 @@ input:checked ~ .dot {
 .makeup table td { padding: 2px; }
 .makeup table pre { margin: 0; }
 .makeup .cm {
-  color: #999988;
+  color: #717160;
   font-style: italic;
 }
 .makeup .cp {
@@ -97,7 +97,7 @@ input:checked ~ .dot {
   font-weight: bold;
 }
 .makeup .c1 {
-  color: #999988;
+  color: #717160;
   font-style: italic;
 }
 .makeup .cs {
@@ -106,7 +106,7 @@ input:checked ~ .dot {
   font-style: italic;
 }
 .makeup .c, .makeup .cd {
-  color: #999988;
+  color: #717160;
   font-style: italic;
 }
 .makeup .err {
@@ -175,22 +175,22 @@ input:checked ~ .dot {
   font-weight: bold;
 }
 .makeup .mf {
-  color: #009999;
+  color: #008080;
 }
 .makeup .mh {
-  color: #009999;
+  color: #008080;
 }
 .makeup .il {
-  color: #009999;
+  color: #008080;
 }
 .makeup .mi {
-  color: #009999;
+  color: #008080;
 }
 .makeup .mo {
-  color: #009999;
+  color: #008080;
 }
 .makeup .m, .makeup .mb, .makeup .mx {
-  color: #009999;
+  color: #008080;
 }
 .makeup .sb {
   color: #d14;
@@ -235,7 +235,7 @@ input:checked ~ .dot {
   color: #999999;
 }
 .makeup .nb {
-  color: #0086B3;
+  color: #007AA3;
 }
 .makeup .nc {
   color: #445588;

--- a/assets/js/dark-mode.js
+++ b/assets/js/dark-mode.js
@@ -1,15 +1,16 @@
-const darkModeToggle = document.getElementById("dark-mode-toggle")
+const darkModeToggleContainer = document.getElementById("dark-mode-toggle-container")
+const darkModeToggleInput = document.getElementById("dark-mode-toggle")
 
 // set up dark mode toggle
 function setDarkMode(on) {
     if (on) {
-        darkModeToggle.checked = true
+        darkModeToggleInput.checked = true
         document.documentElement.classList.add('dark')
         localStorage.theme = 'dark'
         document.getElementById('sun-icon').classList.add('hidden')
         document.getElementById('moon-icon').classList.remove('hidden')
     } else {
-        darkModeToggle.checked = false
+        darkModeToggleInput.checked = false
         document.documentElement.classList.remove('dark')
         localStorage.theme = 'light'
         document.getElementById('moon-icon').classList.add('hidden')
@@ -23,11 +24,11 @@ if (localStorage.theme === 'dark' || (!('theme' in localStorage) && window.match
     setDarkMode(false)
 }
 
-darkModeToggle.addEventListener('click', function (ev) {
-    if (ev.target.checked) {
-        setDarkMode(true)
-    } else {
+darkModeToggleContainer.addEventListener('click', function () {
+    if (darkModeToggleInput.checked) {
         setDarkMode(false)
+    } else {
+        setDarkMode(true)
     }
 })
 

--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -1,3 +1,5 @@
+const colors = require('tailwindcss/colors')
+
 module.exports = {
     purge: [
         '../lib/school_house_web/**/*.ex',
@@ -15,7 +17,7 @@ module.exports = {
                     dark: theme('colors.brand-gray-800')
                 },
                 'body': {
-                    DEFAULT: theme('colors.brand-white'),
+                    DEFAULT: colors.white,
                     dark: theme('colors.brand-gray-700')
                 },
                 'purple': {
@@ -32,16 +34,15 @@ module.exports = {
                 'brand-purple-100': '#cfbae6',
                 'brand-purple-200': '#967ab4',
                 'brand-purple-800': '#7c6f89',
-
-                // white
-                'brand-white': '#fff',
                 
                 // gray
                 'brand-gray-200': '#f5f6f7',
                 'brand-gray-300': '#f4f6f7',
                 'brand-gray-400': '#A1A1AA',
                 'brand-gray-500': '#9fa3a6',
+                'brand-gray-550': '#717171',
                 'brand-gray-600': '#666666',
+                'brand-gray-650': '#4a4a4a',
                 'brand-gray-700': '#3d4449',
                 'brand-gray-750': '#3c4349',
                 'brand-gray-800': '#31373b',
@@ -63,14 +64,14 @@ module.exports = {
                 },
                 heavy : {
                     DEFAULT: theme('colors.brand-gray-800'),
-                    dark: theme('colors.brand-white')
+                    dark: colors.white
                 },
                 light: {
-                    DEFAULT: theme('colors.brand-gray-600'),
+                    DEFAULT: theme('colors.brand-gray-650'),
                     dark: theme('colors.brand-gray-300')
                 },
                 lighter: {
-                    DEFAULT: theme('colors.brand-gray-400'),
+                    DEFAULT: theme('colors.brand-gray-550'),
                     dark: theme('colors.brand-gray-500')
                 },
                 purple: {
@@ -103,7 +104,7 @@ module.exports = {
                             color: theme('colors.brand-purple-800'),
                             '&:hover': {
                                 'background-color': theme('colors.brand-purple-800'),
-                                color: theme('colors.brand-white'),
+                                color: colors.white,
                             }
                         },
                         code: {
@@ -138,7 +139,7 @@ module.exports = {
                             color: theme('colors.brand-purple-200'),
                             '&:hover': {
                                 'background-color': theme('colors.brand-purple-200'),
-                                color: theme('colors.brand-white'),
+                                color: colors.white,
                             }
                         },
                         code: {

--- a/lib/school_house_web/controllers/lesson_controller.ex
+++ b/lib/school_house_web/controllers/lesson_controller.ex
@@ -8,12 +8,13 @@ defmodule SchoolHouseWeb.LessonController do
 
   def index(conn, %{"section" => section}) do
     lessons = Lessons.list(section, Gettext.get_locale(SchoolHouseWeb.Gettext))
-    render(conn, "index.html", lessons: lessons, section: section)
+    page_title = String.capitalize(section)
+    render(conn, "index.html", page_title: page_title, lessons: lessons, section: section)
   end
 
   def lesson(conn, %{"name" => name, "section" => section}) do
     with {:ok, lesson} <- Lessons.get(section, name, Gettext.get_locale(SchoolHouseWeb.Gettext)) do
-      render(conn, "lesson.html", lesson: lesson)
+      render(conn, "lesson.html", page_title: lesson.title, lesson: lesson)
     end
   end
 end

--- a/lib/school_house_web/controllers/page_controller.ex
+++ b/lib/school_house_web/controllers/page_controller.ex
@@ -4,15 +4,15 @@ defmodule SchoolHouseWeb.PageController do
   alias SchoolHouse.{Lessons, Podcasts, Posts}
 
   def index(conn, _params) do
-    render(conn, "index.html", posts: recent_posts())
+    render(conn, "index.html", page_title: "Home", posts: recent_posts())
   end
 
   def podcasts(conn, _params) do
-    render(conn, "podcasts.html", podcasts: Podcasts.list())
+    render(conn, "podcasts.html", page_title: "Podcasts", podcasts: Podcasts.list())
   end
 
   def conferences(conn, _params) do
-    render(conn, "conferences.html")
+    render(conn, "conferences.html", page_title: "Conferences")
   end
 
   def privacy(conn, _params) do

--- a/lib/school_house_web/controllers/post_controller.ex
+++ b/lib/school_house_web/controllers/post_controller.ex
@@ -3,18 +3,20 @@ defmodule SchoolHouseWeb.PostController do
 
   alias SchoolHouse.Posts
 
+  @page_title "Blog"
+
   def index(conn, params) do
     posts =
       params
       |> current_page()
       |> Posts.page()
 
-    render(conn, "index.html", posts: posts, pages: Posts.pages())
+    render(conn, "index.html", page_title: @page_title, posts: posts, pages: Posts.pages())
   end
 
   def show(conn, %{"slug" => slug}) do
     post = Posts.get(slug)
-    render(conn, "post.html", post: post)
+    render(conn, "post.html", page_title: @page_title, post: post)
   end
 
   defp current_page(params) do

--- a/lib/school_house_web/templates/layout/_dark_mode_toggle.html.leex
+++ b/lib/school_house_web/templates/layout/_dark_mode_toggle.html.leex
@@ -1,6 +1,6 @@
-<label for="dark-mode-toggle" class="flex items-center cursor-pointer">
+<div id="dark-mode-toggle-container" class="flex items-center cursor-pointer">
   <div class="relative">
-    <input type="checkbox" id="dark-mode-toggle" class="sr-only">
+    <input type="checkbox" id="dark-mode-toggle" class="sr-only" aria-label="Dark Mode Toggle">
     <div class="block bg-gray-600 w-14 h-8 rounded-full">
     </div>
     <div class="dot absolute left-1 top-1 bg-body dark:bg-purple-dark w-6 h-6 rounded-full flex items-center justify-center transition-all">
@@ -24,4 +24,4 @@
       </svg>
     </div>
   </div>
-</label>
+</div>

--- a/lib/school_house_web/templates/layout/_header.html.leex
+++ b/lib/school_house_web/templates/layout/_header.html.leex
@@ -2,7 +2,7 @@
   <nav id="nav" class="w-64 md:w-full relative bg-nav dark:bg-nav-dark md:border-b-4 border-brand-purple-800 text-primary dark:text-primary-dark shadow-md transition-margin duration-300 overflow-y-scroll md:overflow-y-visible -ml-64 md:ml-0">
     <div class="container mx-auto flex flex-col md:flex-row justify-between">
       <%= link(to: Routes.page_path(@conn, :index, current_locale()), class: "flex title-font font-medium items-center text-heavy dark:text-heavy-dark mb-4 md:mb-0 mx-auto md:mx-2 mt-6 md:mt-0") do %>
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="w-10 h-10 md:w-7 md:h-7 lg:h-10 lg:w-10 p-2 text-brand-white rounded-full bg-purple" viewBox="0 0 24 24">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="w-10 h-10 md:w-7 md:h-7 lg:h-10 lg:w-10 p-2 text-white rounded-full bg-purple" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z" />
         </svg>
         <span class="ml-3 text-2xl font-extrabold text-primary dark:text-primary-dark tracking-tight">Elixir School</span>

--- a/lib/school_house_web/templates/page/_newsletter.html.eex
+++ b/lib/school_house_web/templates/page/_newsletter.html.eex
@@ -5,7 +5,7 @@
         <h2 class="text-3xl font-extrabold tracking-tight text-white">
           Sign up for our newsletter
         </h2>
-        <p class="max-w-3xl mt-4 text-lg text-indigo-100">
+        <p class="max-w-3xl mt-4 text-lg text-white">
           Join the Elixir School newsletter to keep up with the latest lessons, blog posts, and opportunities within the community.
         </p>
       </div>
@@ -17,7 +17,7 @@
             Notify me
           </button>
         </form>
-        <p class="mt-3 text-sm text-indigo-100">
+        <p class="mt-3 text-sm text-white">
           We care about the protection of your data. Read our
           <a href="<%= Routes.page_path(@conn, :privacy) %>" class="font-medium text-white underline">
             Privacy Policy.

--- a/lib/school_house_web/templates/page/index.html.eex
+++ b/lib/school_house_web/templates/page/index.html.eex
@@ -1,9 +1,9 @@
 <section class="text-primary dark:text-primary-dark body-font">
   <div class="container px-5 py-20 md:py-24 mx-auto">
     <div class="items-center text-center">
-      <p class="mb-6 text-4xl font-extrabold tracking-tight leading-8 text-purple dark:text-purple-dark sm:text-4xl">
+      <h1 class="mb-6 text-4xl font-extrabold tracking-tight leading-8 text-purple dark:text-purple-dark sm:text-4xl">
         Welcome to Elixir School!
-      </p>
+      </h1>
       <p class="mb-6 leading-relaxed">
         Elixir School is the premier destination for people looking to learn and master the Elixir programming language.
         Whether you’re a seasoned veteran or this is your first time, you’ll find what you need in lessons and auxiliary resources.
@@ -23,7 +23,7 @@
   </div>
   <div class="relative flex justify-center">
     <span class="px-2 text-lighter dark:text-lighter-dark dark:bg-body-dark bg-body">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" class="w-10 h-10 p-2 dark:text-heavy-dark text-brand-white rounded-full bg-purple" viewBox="0 0 24 24">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" class="w-10 h-10 p-2 dark:text-heavy-dark text-white rounded-full bg-purple" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z" />
       </svg>
     </span>
@@ -33,9 +33,9 @@
 <section class="text-primary body-font dark:text-primary-dark">
   <div class="container px-5 py-24 mx-auto">
     <div class="mb-20">
-      <p class="mt-2 text-4xl font-extrabold tracking-tight text-center leading-8 text-purple dark:text-purple-dark sm:text-4xl">
+      <h2 class="mt-2 text-4xl font-extrabold tracking-tight text-center leading-8 text-purple dark:text-purple-dark sm:text-4xl">
         Why Elixir?
-      </p>
+      </h2>
       <p class="mt-3 text-xl text-center text-heavy dark:text-heavy-dark sm:mt-4">
         Discover why Elixir's popularity has skyrocketed and new companies adopt it daily.
       </p>
@@ -109,7 +109,7 @@
   </div>
   <div class="relative flex justify-center">
     <span class="px-2 text-lighter dark:text-lighter-dark dark:bg-body-dark bg-body">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" class="w-10 h-10 p-2 dark:text-heavy-dark text-brand-white rounded-full bg-purple" viewBox="0 0 24 24">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" class="w-10 h-10 p-2 dark:text-heavy-dark text-white rounded-full bg-purple" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z" />
       </svg>
     </span>
@@ -180,7 +180,7 @@
   </div>
   <div class="relative flex justify-center">
     <span class="px-2 text-lighter dark:text-lighter-dark bg-body dark:bg-body-dark">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" class="w-10 h-10 p-2 dark:text-heavy-dark text-brand-white rounded-full bg-purple" viewBox="0 0 24 24">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" class="w-10 h-10 p-2 dark:text-heavy-dark text-white rounded-full bg-purple" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
       </svg>
     </span>

--- a/lib/school_house_web/templates/post/post.html.eex
+++ b/lib/school_house_web/templates/post/post.html.eex
@@ -16,11 +16,11 @@
     </div>
 
     <div class="pt-6 text-center">
-      <span class="text-2xl leading-8 font-extrabold tracking-tight text-primary dark:text-primary-dark sm:text-2xl"><%= @post.title %></span>
+      <h1 class="text-2xl leading-8 font-extrabold tracking-tight text-primary dark:text-primary-dark sm:text-2xl"><%= @post.title %></h1>
     </div>
 
     <div class="py-2 text-center">
-      <span class="text-medium leading-8 tracking-tight text-primary dark:text-primary-dark sm:text-large ">By <%= @post.author %></span>
+      <h2 class="text-medium leading-8 tracking-tight text-primary dark:text-primary-dark sm:text-large ">By <%= @post.author %></h2>
     </div>
 
     <div class="bg-brand-gray-300 dark:bg-brand-gray-800 rounded-xl p-4 mb-3 text-xl text-light dark:text-light-dark sm:mb-4 text-center"><%= raw @post.excerpt %></div>


### PR DESCRIPTION
# Overview

Addresses (but does not close) #35

* Updated the colors used on the website to increase the contrast between text and background to meet WCAG 2 AA contrast thresholds.
* Updated the dark mode toggle to not use a label as a wrapper element. Further improved accessibility of this control by labeling the input itself.
* Added page titles to controllers that were missing them
* Converted some `p` and `span` tags to header tags to better semantically describe the content