### PR TITLE
Add 'By The Numbers' Section to Home Page

### DIFF
--- a/lib/school_house_web/templates/page/index.html.eex
+++ b/lib/school_house_web/templates/page/index.html.eex
@@ -116,6 +116,88 @@
   </div>
 </div>
 
+<section class="text-primary body-font dark:text-primary-dark">
+  <div class="container px-5 py-24 mx-auto">
+    <div class="mb-20">
+      <h2 class="mt-2 text-4xl font-extrabold tracking-tight text-center leading-8 text-purple dark:text-purple-dark sm:text-4xl">
+        By The Numbers
+      </h2>
+      <p class="mt-3 text-xl text-center text-heavy dark:text-heavy-dark sm:mt-4">
+        If you still are not convinced, here are some numbers that exemplify Elixir's growth.
+      </p>
+    </div>
+    <div class="flex flex-wrap -mx-4 -mt-4 -mb-10 sm:-m-4 justify-around">
+      <div class="w-52 h-56 px-3 my-3 py-8 bg-purple dark:bg-purple-dark rounded-lg flex flex-col items-center justify-between">
+        <p class="text-white font-bold text-2xl text-center">100+ <br /> Conferences</p>
+
+        <%= link(to: "https://github.com/elixir-lang/elixir/wiki/Conferences", class: "inline-flex items-center mx-auto text-white") do %>
+            See Them Here
+            <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="w-4 h-4 ml-2" viewBox="0 0 24 24">
+              <path d="M5 12h14M12 5l7 7-7 7"></path>
+            </svg>
+          <% end %>
+      </div>
+
+      <div class="w-52 h-56 px-3 my-3 py-8 bg-purple dark:bg-purple-dark rounded-lg flex flex-col items-center justify-between">
+        <p class="text-white font-bold text-2xl text-center">6 Podcasts <br /> and Counting</p>
+
+        <%= link(to: Routes.page_path(@conn, :podcasts, current_locale()), class: "inline-flex items-center mx-auto text-white") do %>
+            See Them Here
+            <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="w-4 h-4 ml-2" viewBox="0 0 24 24">
+              <path d="M5 12h14M12 5l7 7-7 7"></path>
+            </svg>
+          <% end %>
+      </div>
+
+      <div class="w-52 h-56 px-3 my-3 py-8 bg-purple dark:bg-purple-dark rounded-lg flex flex-col items-center justify-between">
+        <p class="text-white font-bold text-2xl text-center">25 Lanuages <br /> With Lesson <br /> Translations</p>
+
+        <%= link(to: "https://github.com/elixirschool/elixirschool", class: "inline-flex items-center mx-auto text-white") do %>
+            See Them Here
+            <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="w-4 h-4 ml-2" viewBox="0 0 24 24">
+              <path d="M5 12h14M12 5l7 7-7 7"></path>
+            </svg>
+          <% end %>
+      </div>
+
+      <div class="w-52 h-56 px-3 my-3 py-8 bg-purple dark:bg-purple-dark rounded-lg flex flex-col items-center justify-between">
+        <p class="text-white font-bold text-2xl text-center">600+ Companies <br /> Using Elixir</p>
+
+        <%= link(to: "https://elixir-companies.com/en", class: "inline-flex items-center mx-auto text-white") do %>
+            See Them Here
+            <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="w-4 h-4 ml-2" viewBox="0 0 24 24">
+              <path d="M5 12h14M12 5l7 7-7 7"></path>
+            </svg>
+          <% end %>
+      </div>
+
+      <div class="w-52 h-56 px-3 my-3 py-8 bg-purple dark:bg-purple-dark rounded-lg flex flex-col items-center justify-between">
+        <p class="text-white font-bold text-2xl text-center">13,000+ Packages <br /> On Hex</p>
+
+        <%= link(to: "https://hex.pm/", class: "inline-flex items-center mx-auto text-white") do %>
+            See Them Here
+            <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="w-4 h-4 ml-2" viewBox="0 0 24 24">
+              <path d="M5 12h14M12 5l7 7-7 7"></path>
+            </svg>
+          <% end %>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="relative">
+  <div class="absolute inset-0 flex items-center" aria-hidden="true">
+    <div class="w-full border-t border-gray-300"></div>
+  </div>
+  <div class="relative flex justify-center">
+    <span class="px-2 text-lighter dark:text-lighter-dark dark:bg-body-dark bg-body">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" class="w-10 h-10 p-2 dark:text-heavy-dark text-white rounded-full bg-purple" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z" />
+      </svg>
+    </span>
+  </div>
+</div>
+
 <!--
 <div class="bg-body dark:bg-body-dark">
   <div class="px-4 py-12 mx-auto max-w-7xl sm:px-6 lg:py-16 lg:px-8">


### PR DESCRIPTION
# Overview
This pr adds a section the home page to show stats about Elixir's adoption and closes #55.

The copy could probably be tweaked, so I welcome any feedback on that (as well as the code itself 😅)!

I went down a little bit of a rabbit hole trying to come up with a stat for the number of courses offered and couldn't find a good source for it, so I left it out of this. I am happy to add it though if anyone has suggestions for that stat!

## Screenshots

<img width="1438" alt="Screen Shot 2021-07-13 at 7 34 09 PM" src="https://user-images.githubusercontent.com/1526888/125546823-db3ad273-3eee-4b3f-856b-a1912a489254.png">
<img width="1439" alt="Screen Shot 2021-07-13 at 7 34 26 PM" src="https://user-images.githubusercontent.com/1526888/125546826-e597cefc-798e-4c1a-aca0-92fb36d90573.png">
