### PR TITLE
Elixir version 1.12

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule SchoolHouse.MixProject do
     [
       app: :school_house,
       version: "0.1.0",
-      elixir: "~> 1.7",
+      elixir: "~> 1.12",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
This PR sets 1.12 as the Elixir version in Mix.exs

I'm not so sure about including a `.tool-versions` file as some devs may not want to use `asdf`.