### PR TITLE
fix HTML structure of Why page

### DIFF
--- a/lib/school_house_web/templates/page/why.html.eex
+++ b/lib/school_house_web/templates/page/why.html.eex
@@ -1,9 +1,9 @@
 <div class="pt-20 pb-4 md:py-12 bg-body dark:bg-body-dark">
   <div class="px-4 mx-auto max-w-7xl sm:px-6 lg:px-8">
     <div class="lg:text-center">
-      <p class="mt-2 text-4xl font-extrabold tracking-tight leading-8 text-purple dark:text-purple-dark sm:text-4xl">
+      <h1 class="mt-2 text-4xl font-extrabold tracking-tight leading-8 text-purple dark:text-purple-dark sm:text-4xl">
         Why Elixir?
-      </p>
+      </h1>
       <p class="max-w-2xl mt-4 text-xl text-light dark:text-light-dark lg:mx-auto">
         Elixir is a wonderful language but don't take our word for it. Let's look at some of the reasons you and your organization should adopt Elixir.
       </p>
@@ -14,21 +14,21 @@
 <div class="bg-body dark:bg-body-dark">
   <div class="px-4 py-2 md:py-16 mx-auto max-w-7xl sm:px-6 lg:py-24 lg:px-8 lg:grid lg:grid-cols-3 lg:gap-x-8">
     <div class="mt-12 lg:mt-0 lg:col-span-2">
-      <dl class="space-y-10 sm:space-y-0 sm:grid sm:grid-cols-1 sm:grid-rows-3 sm:grid-flow-col sm:gap-x-6 sm:gap-y-10 lg:gap-x-8">
+      <div class="space-y-10 sm:space-y-0 sm:grid sm:grid-cols-1 sm:grid-rows-3 sm:grid-flow-col sm:gap-x-6 sm:gap-y-10 lg:gap-x-8">
         <div class="flex">
           <!-- Heroicon name: outline/check -->
           <svg class="flex-shrink-0 w-6 h-6 font-bold text-purple dark:text-purple-dark" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7" />
           </svg>
           <div class="ml-3">
-            <dt class="text-lg font-medium text-heavy dark:text-heavy-dark leading-6">
+            <h3 class="text-lg font-medium text-heavy dark:text-heavy-dark leading-6">
               Immutability
-            </dt>
-            <dd class="mt-2 text-base text-light dark:text-light-dark">
+            </h3>
+            <div class="mt-2 text-base text-light dark:text-light-dark">
               Data is not mutated, rather transformed, into a new set of data.
               By eliminating the ability to mutate state outside of scope, functional programs are often easier to follow and contain fewer bugs.
               This has the added benefit of improving support for concurrency and thus scalability of systems.
-            </dd>
+            </div>
           </div>
         </div>
 
@@ -38,14 +38,14 @@
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7" />
           </svg>
           <div class="ml-3">
-            <dt class="text-lg font-medium text-heavy dark:text-heavy-dark leading-6">
+            <h3 class="text-lg font-medium text-heavy dark:text-heavy-dark leading-6">
               Focus on Functions
-            </dt>
-            <dd class="mt-2 text-base text-light dark:text-light-dark">
+            </h3>
+            <div class="mt-2 text-base text-light dark:text-light-dark">
               Problems are decomposed into simple functions with an emphasis on no side-effects.
               These "pure functions" always produce the same results for a given input and change nothing.
               Since functions are first class citizens in Functional Programming we're able to easily re-use our functions throughout our applications.
-            </dd>
+            </div>
           </div>
         </div>
 
@@ -54,21 +54,22 @@
           <svg class="flex-shrink-0 w-6 h-6 font-bold text-purple dark:text-purple-dark" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7" />
           </svg>
+
           <div class="ml-3">
-            <dt class="text-lg font-medium text-heavy dark:text-heavy-dark leading-6">
+            <h3 class="text-lg font-medium text-heavy dark:text-heavy-dark leading-6">
               Easy to Test
-            </dt>
-            <dd class="mt-2 text-base text-light dark:text-light-dark">
+            </h3>
+            <div class="mt-2 text-base text-light dark:text-light-dark">
               The very nature of functional programming, small functions with no side-effects, makes testing easy.
               Bundled with Elixir is the venerable ExUnit library providing everything necessary to comprehensively test your applications.
-            </dd>
+            </div>
           </div>
         </div>
 
-      </dl>
+      </div>
     </div>
     <div>
-      <p class="mt-8 md:mt-2 text-3xl font-extrabold text-purple dark:text-purple-dark">Functional Programming</p>
+      <h2 class="mt-8 md:mt-2 text-3xl font-extrabold text-purple dark:text-purple-dark">Functional Programming</h2>
       <p class="mt-4 mb-16 md:mb-0 text-lg text-light dark:text-light-dark">
         While its roots are in lambda calculus, functional programming can be fun, easy, and approachable for everyone! By focusing on breaking problems down into simple, side-effect free, functions we can ensure fewer bugs, better test coverage, while incrementally building our solutions through the composition of well tested functions.
       </p>
@@ -93,20 +94,20 @@
 <div class="bg-body dark:bg-body-dark">
   <div class="px-4 py-16 mx-auto max-w-7xl sm:px-6 lg:py-24 lg:px-8 lg:grid lg:grid-cols-3 lg:gap-x-8">
     <div>
-      <p class="mt-2 text-3xl font-extrabold text-purple dark:text-purple-dark">Feature Packed</p>
+      <h2 class="mt-2 text-3xl font-extrabold text-purple dark:text-purple-dark">Feature Packed</h2>
       <p class="mt-4 text-lg text-light dark:text-light-dark">Elixir and the BEAM virtual machine pack a serious punch when it comes to features. With over 35 years of experience the Erlang runtime system has proven itself time and time again as solid platform for distributed, high-available systems.</p>
     </div>
     <div class="mt-12 lg:mt-0 lg:col-span-2">
-      <dl class="space-y-10 sm:space-y-0 sm:grid sm:grid-cols-2 sm:grid-rows-3 sm:grid-flow-col sm:gap-x-6 sm:gap-y-10 lg:gap-x-8">
+      <div class="space-y-10 sm:space-y-0 sm:grid sm:grid-cols-2 sm:grid-rows-3 sm:grid-flow-col sm:gap-x-6 sm:gap-y-10 lg:gap-x-8">
         <div class="flex">
           <!-- Heroicon name: outline/check -->
           <svg class="flex-shrink-0 w-6 h-6 text-purple dark:text-purple-dark" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7" />
           </svg>
           <div class="ml-3">
-            <dt class="text-lg font-medium text-heavy dark:text-heavy-dark leading-6">
+            <h3 class="text-lg font-medium text-heavy dark:text-heavy-dark leading-6">
               <%= gettext("Scalable") %>
-            </dt>
+            </h3>
           </div>
         </div>
 
@@ -116,9 +117,9 @@
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7" />
           </svg>
           <div class="ml-3">
-            <dt class="text-lg font-medium text-heavy dark:text-heavy-dark leading-6">
+            <h3 class="text-lg font-medium text-heavy dark:text-heavy-dark leading-6">
               Fault Tolerant
-            </dt>
+            </h3>
           </div>
         </div>
 
@@ -128,9 +129,9 @@
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7" />
           </svg>
           <div class="ml-3">
-            <dt class="text-lg font-medium text-heavy dark:text-heavy-dark leading-6">
+            <h3 class="text-lg font-medium text-heavy dark:text-heavy-dark leading-6">
               Extensible
-            </dt>
+            </h3>
           </div>
         </div>
 
@@ -140,9 +141,9 @@
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7" />
           </svg>
           <div class="ml-3">
-            <dt class="text-lg font-medium text-heavy dark:text-heavy-dark leading-6">
+            <h3 class="text-lg font-medium text-heavy dark:text-heavy-dark leading-6">
               Compatible with Erlang
-            </dt>
+            </h3>
           </div>
         </div>
 
@@ -152,9 +153,9 @@
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7" />
           </svg>
           <div class="ml-3">
-            <dt class="text-lg font-medium text-heavy dark:text-heavy-dark leading-6">
+            <h3 class="text-lg font-medium text-heavy dark:text-heavy-dark leading-6">
               Concurrency
-            </dt>
+            </h3>
           </div>
         </div>
 
@@ -164,13 +165,12 @@
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7" />
           </svg>
           <div class="ml-3">
-            <dt class="text-lg font-medium text-heavy dark:text-heavy-dark leading-6">
+            <h3 class="text-lg font-medium text-heavy dark:text-heavy-dark leading-6">
               Performant
-            </dt>
-            </dd>
+            </h3>
           </div>
         </div>
-      </dl>
+      </div>
     </div>
   </div>
 </div>
@@ -194,20 +194,20 @@
       <h2 class="text-3xl font-extrabold text-purple dark:text-purple-dark">Vibrant Ecosystem</h2>
       <p class="mt-4 text-lg text-light dark:text-light-dark">The community and ecosystem that have grown up with the language remain one of the alluring parts of Elixir.</p>
     </div>
-    <dl class="mt-12 space-y-10 sm:space-y-0 sm:grid sm:grid-cols-2 sm:gap-x-6 sm:gap-y-12 lg:grid-cols-3 lg:gap-x-8">
+    <div class="mt-12 space-y-10 sm:space-y-0 sm:grid sm:grid-cols-2 sm:gap-x-6 sm:gap-y-12 lg:grid-cols-3 lg:gap-x-8">
       <div class="flex">
         <!-- Heroicon name: outline/check -->
         <svg class="flex-shrink-0 w-6 h-6 font-bold text-purple dark:text-purple-dark" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7" />
         </svg>
         <div class="ml-3">
-          <dt class="text-lg font-medium text-heavy dark:text-heavy-dark leading-6">
+          <h3 class="text-lg font-medium text-heavy dark:text-heavy-dark leading-6">
             Slack
-          </dt>
-          <dd class="mt-2 text-base text-light dark:text-light-dark">
+          </h3>
+          <div class="mt-2 text-base text-light dark:text-light-dark">
           The Elixir Slack is a popular destination for many in the community.
           <a target="_blank" href="https://elixir-slackin.herokuapp.com/" class="font-bold text-purple dark:text-purple-dark">Request your invite today!</a>
-          </dd>
+          </div>
         </div>
       </div>
 
@@ -217,13 +217,13 @@
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7" />
         </svg>
         <div class="ml-3">
-          <dt class="text-lg font-medium text-heavy dark:text-heavy-dark leading-6">
+          <h3 class="text-lg font-medium text-heavy dark:text-heavy-dark leading-6">
             Discord
-          </dt>
-          <dd class="mt-2 text-base text-light dark:text-light-dark">
+          </h3>
+          <div class="mt-2 text-base text-light dark:text-light-dark">
             A Slack alternative built with Elixir is fast becoming a popular chat option for the community.
             <a target="_blank" href="https://discord.com/invite/elixir" class="font-bold text-purple dark:text-purple-dark">Be sure to check it out!</a>
-          </dd>
+          </div>
         </div>
       </div>
 
@@ -233,12 +233,12 @@
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7" />
         </svg>
         <div class="ml-3">
-          <dt class="text-lg font-medium text-heavy dark:text-heavy-dark leading-6">
+          <h3 class="text-lg font-medium text-heavy dark:text-heavy-dark leading-6">
             Forum
-          </dt>
-          <dd class="mt-2 text-base text-light dark:text-light-dark">
+          </h3>
+          <div class="mt-2 text-base text-light dark:text-light-dark">
           Prefer the forum format for your questions? No problem! Head over to <a class="font-bold text-purple dark:text-purple-dark" href="https://elixirforum.com" target="_blank">Elixir Forum</a> to join the conversation.
-          </dd>
+          </div>
         </div>
       </div>
 
@@ -248,12 +248,12 @@
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7" />
         </svg>
         <div class="ml-3">
-          <dt class="text-lg font-medium text-heavy dark:text-heavy-dark leading-6">
+          <h3 class="text-lg font-medium text-heavy dark:text-heavy-dark leading-6">
             Meetups
-          </dt>
-          <dd class="mt-2 text-base text-light dark:text-light-dark">
+          </h3>
+          <div class="mt-2 text-base text-light dark:text-light-dark">
           With over 150 meetups, you're sure to find local Elixir enthusiasts. Check out <a href="https://www.meetup.com/topics/elixir/" target="_blank" class="font-bold text-purple dark:text-purple-dark">Meetup.com</a> for more.
-          </dd>
+          </div>
         </div>
       </div>
 
@@ -263,12 +263,12 @@
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7" />
         </svg>
         <div class="ml-3">
-          <dt class="text-lg font-medium text-heavy dark:text-heavy-dark leading-6">
+          <h3 class="text-lg font-medium text-heavy dark:text-heavy-dark leading-6">
             Hashtags
-          </dt>
-          <dd class="mt-2 text-base text-light dark:text-light-dark">
+          </h3>
+          <div class="mt-2 text-base text-light dark:text-light-dark">
           Be sure to follow the popular Elixir hashtags <a href="https://twitter.com/hashtag/MyElixirStatus" target="_blank" class="font-bold text-purple dark:text-purple-dark">#MyElixirStatus</a>, <a href="https://twitter.com/hashtag/WeBEAMTogether" target="_blank" class="font-bold text-purple dark:text-purple-dark">#WeBEAMTogether</a>, and <a href="https://twitter.com/hashtag/ElixirLang" target="_blank" class="font-bold text-purple dark:text-purple-dark">#Elixirlang</a> on Twitter.
-          </dd>
+          </div>
         </div>
       </div>
 
@@ -278,15 +278,15 @@
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7" />
         </svg>
         <div class="ml-3">
-          <dt class="text-lg font-medium text-heavy dark:text-heavy-dark leading-6">
+          <h3 class="text-lg font-medium text-heavy dark:text-heavy-dark leading-6">
             Conferences
-          </dt>
-          <dd class="mt-2 text-base text-light dark:text-light-dark">
+          </h3>
+          <div class="mt-2 text-base text-light dark:text-light-dark">
             More to come...
-          </dd>
+          </div>
         </div>
       </div>
 
-    </dl>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
The "Why Choose Elixir" page has 65 HTML issues due to its structure:

https://rocketvalidator.com/s/7d40eccc-c4a6-4915-825e-18149434e117/p/4668014/i

The problem lies in the use of `<dl>` and nested `<div>`. It looks like it can accept one level of nested `<div>`, but no more.

As `<dl>` are intended as definition lists, and we're not really defining terms, I think we should instead rely on a simple h1 / h2 / h3 structure, because the content really is structured like this:

# Why Elixir? (h1)

## Functional Programming (h2)

While its roots are in lambda calculus...

### Immutability (h3)

Data is not transformed...

### Focus on Functions (h3)

Problems are decomposed...

### Easy to Test (h3)

The very nature...

## Feature Packed (h2)

Elixir and the BEAM...

### Scalable (h3)

--

... you get the idea. This gives a simpler and easier to understand structure. And it gets us from 65 HTML issues to only 5 (soon to be fixed as well), here's the report from my ngrokked machine:

https://rocketvalidator.com/s/f5ca4612-6154-483f-a0c9-f64d02c39dd6/p/4673848/i

Content keeps displaying as before, here's a screenshot from my dev:

![Opera Instantánea_2021-07-21_202011_elixirschool-jaime ngrok io](https://user-images.githubusercontent.com/2629/126539735-6fe1c0d0-673e-4f4d-b483-6637d306c68f.png)

