### PR TITLE
fixes locale menu glitch using x-cloak

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -531,3 +531,8 @@ input:checked ~ .dot {
 body, body * {
   transition: background-color 0.25s ease, color 0.25s ease;
 }
+
+/* Alpine.js */
+/* https://alpinejs.dev/directives/cloak */
+
+[x-cloak] { display: none !important; }

--- a/lib/school_house_web/templates/layout/_locale_menu.html.leex
+++ b/lib/school_house_web/templates/layout/_locale_menu.html.leex
@@ -7,7 +7,7 @@
             </svg>
         </button>
     </div>
-    <div x-show="isOpen" @click.away=" { isOpen = false } " class="origin-top-right absolute left-0 mt-2 w-24 rounded-md shadow-lg bg-white dark:bg-nav-dark ring-1 ring-black ring-opacity-5 focus:outline-none" role="menu" aria-orientation="vertical" aria-labelledby="locale-menu">
+    <div x-cloak x-show="isOpen" @click.away=" { isOpen = false } " class="origin-top-right absolute left-0 mt-2 w-24 rounded-md shadow-lg bg-white dark:bg-nav-dark ring-1 ring-black ring-opacity-5 focus:outline-none" role="menu" aria-orientation="vertical" aria-labelledby="locale-menu">
         <div class="py-1" role="none">
         <%= for locale <- supported_locales() do %>
             <a href="<%= current_page_locale_path(@conn, locale) %>" class="block px-4 py-2 text-sm text-primary dark:text-primary-dark hover:bg-brand-gray-300 dark:hover:bg-purple-dark hover:font-bold" role="menuitem"><%= locale %></a>


### PR DESCRIPTION
There's a glitch on the locale menu, when you click on a different section the locale menu is shown unfolded until some microseconds later Alpine hides it:

https://user-images.githubusercontent.com/2629/126673357-843af530-f3c9-4d89-b53d-f18932e2ae94.mov

This PR fixes it by using the `x-cloak` directive:

See https://alpinejs.dev/directives/cloak


