### PR TITLE
Fix locale menu for pages outside of locale scope

### DIFF
--- a/lib/school_house/posts.ex
+++ b/lib/school_house/posts.ex
@@ -2,8 +2,10 @@ defmodule SchoolHouse.Posts do
   @moduledoc """
   Stores our posts in a module attribute and provides mechanisms to retrieve them
   """
+  alias SchoolHouse.Content.Post
+
   use NimblePublisher,
-    build: SchoolHouse.Content.Post,
+    build: Post,
     from: Application.compile_env!(:school_house, :blog_dir),
     as: :posts,
     highlighters: [:makeup_elixir, :makeup_erlang]
@@ -13,7 +15,12 @@ defmodule SchoolHouse.Posts do
                    {slug, post}
                  end)
 
-  def get(slug), do: Map.get(@posts_by_slug, slug)
+  def get(slug) do
+    case Map.get(@posts_by_slug, slug) do
+      nil -> {:error, :not_found}
+      %Post{} = post -> {:ok, post}
+    end
+  end
 
   def page(n), do: Enum.at(@paged_posts, n)
 

--- a/lib/school_house_web/controllers/post_controller.ex
+++ b/lib/school_house_web/controllers/post_controller.ex
@@ -2,6 +2,9 @@ defmodule SchoolHouseWeb.PostController do
   use SchoolHouseWeb, :controller
 
   alias SchoolHouse.Posts
+  alias SchoolHouseWeb.FallbackController
+
+  action_fallback FallbackController
 
   @page_title "Blog"
 
@@ -15,8 +18,9 @@ defmodule SchoolHouseWeb.PostController do
   end
 
   def show(conn, %{"slug" => slug}) do
-    post = Posts.get(slug)
-    render(conn, "post.html", page_title: @page_title, post: post)
+    with {:ok, post} <- Posts.get(slug) do
+      render(conn, "post.html", page_title: @page_title, post: post)
+    end
   end
 
   defp current_page(params) do

--- a/lib/school_house_web/templates/post/post.html.eex
+++ b/lib/school_house_web/templates/post/post.html.eex
@@ -1,6 +1,5 @@
 <section class="container w-3/4 mb-6 items-center">
-  <%= if @post do %>
-    <div class="py-6 text-center">
+  <div class="py-6 text-center">
       <span class="text-4xl leading-8 font-extrabold tracking-tight text-purple dark:text-purple-dark sm:text-4xl ">Elixir School</span>
     </div>
 
@@ -28,11 +27,4 @@
     <div class="prose dark:prose-dark">
       <%= raw @post.body %>
     </div>
-  <% else %>
-    <div class="my-20 text-center">
-      <span class="text-2xl font-bold tracking-tight text-light dark:text-light-dark sm:text-2xl">
-        Sorry, we couldn&apos;t find the post you are looking for.
-      </span>
-    </div>
-  <% end %>
 </section>

--- a/lib/school_house_web/views/html_helpers.ex
+++ b/lib/school_house_web/views/html_helpers.ex
@@ -14,7 +14,7 @@ defmodule SchoolHouseWeb.HtmlHelpers do
   end
 
   def current_page_locale_path(%{request_path: request_path}, locale) do
-    String.replace(request_path, current_locale(), locale, global: false)
+    String.replace(request_path, "/#{current_locale()}/", "/#{locale}/", global: false)
   end
 
   def friendly_version({major, minor, patch}), do: "#{major}.#{minor}.#{patch}"

--- a/test/school_house/posts_test.exs
+++ b/test/school_house/posts_test.exs
@@ -5,7 +5,11 @@ defmodule SchoolHouse.PostsTest do
 
   describe "get/1" do
     test "returns a specific post by slug" do
-      assert %Post{title: "Title for a post"} = Posts.get("test_blog_post")
+      assert {:ok, %Post{title: "Title for a post"}} = Posts.get("test_blog_post")
+    end
+
+    test "returns error if post not found" do
+      assert {:error, :not_found} == Posts.get("unknown")
     end
   end
 

--- a/test/school_house_web/controllers/post_controller_test.exs
+++ b/test/school_house_web/controllers/post_controller_test.exs
@@ -21,10 +21,9 @@ defmodule SchoolHouseWeb.PostControllerTest do
 
     test "renders a page with an error message when the blog post is not found", %{conn: conn} do
       conn = get(conn, Routes.post_path(conn, :show, "test_no_post_found"))
-      body = html_response(conn, 200)
+      body = html_response(conn, 404)
 
-      assert body =~ "Sorry, we couldn&apos;t find the post you are looking for."
-      refute body =~ "By Sean Callan"
+      assert body =~ "Page not found"
     end
   end
 end

--- a/test/school_house_web/views/html_helpers_test.exs
+++ b/test/school_house_web/views/html_helpers_test.exs
@@ -29,11 +29,12 @@ defmodule SchoolHouseWeb.HtmlHelpersTest do
                :get
                |> build_conn("/es/ecto/changesets")
                |> HtmlHelpers.current_page_locale_path("fr")
+    end
 
-      # With or without a leading slash, the replacement is correct
-      assert "fr/ecto/changesets" ==
+    test "returns the same page path for a page without locale scope" do
+      assert "/blog/instrumenting-phoenix" ==
                :get
-               |> build_conn("es/ecto/changesets")
+               |> build_conn("/blog/instrumenting-phoenix")
                |> HtmlHelpers.current_page_locale_path("fr")
     end
   end


### PR DESCRIPTION
This PR fixes #85 by:

* Fixing broken links generated in locale menu
* Return 404 page for Blog post not found instead of 200 with custom content.

This will make it easier for users and crawler bots to properly find the internal web pages :)
 
