### PR TITLE
Fix Dark Mode Flicker and Handle Invalid Locales

### DIFF
--- a/assets/js/dark-mode.js
+++ b/assets/js/dark-mode.js
@@ -18,7 +18,7 @@ function setDarkMode(on) {
     }
 }
 
-if (localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+if (document.documentElement.classList.contains('dark')) {
     setDarkMode(true)
 } else {
     setDarkMode(false)

--- a/assets/js/initialize-theme.js
+++ b/assets/js/initialize-theme.js
@@ -1,0 +1,7 @@
+if (
+  localStorage.getItem('theme') === 'dark' ||
+  (!('theme' in localStorage) &&
+    window.matchMedia('(prefers-color-scheme: dark)').matches)
+) {
+  document.documentElement.classList.add('dark');
+}

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -16,7 +16,8 @@ module.exports = (env, options) => {
       ]
     },
     entry: {
-      'app': glob.sync('./vendor/**/*.js').concat(['./js/app.js'])
+      'app': glob.sync('./vendor/**/*.js').concat(['./js/app.js']),
+      'initialize-theme': './js/initialize-theme.js',
     },
     output: {
       filename: '[name].js',

--- a/lib/school_house_web/plugs/set_locale_plug.ex
+++ b/lib/school_house_web/plugs/set_locale_plug.ex
@@ -3,20 +3,41 @@ defmodule SchoolHouseWeb.SetLocalePlug do
   Set the process' locale given the path params value
   """
 
+  import Phoenix.Controller, only: [redirect: 2]
+  import Plug.Conn, only: [halt: 1]
+
   @spec init(any) :: any
   def init(opts), do: opts
 
   @spec call(Plug.Conn.t(), any) :: Plug.Conn.t()
   def call(conn, _opts) do
     locale = Map.get(conn.path_params, "locale", default_locale())
-    Gettext.put_locale(SchoolHouseWeb.Gettext, locale)
 
-    conn
+    case valid_locale?(locale) do
+      true ->
+        Gettext.put_locale(SchoolHouseWeb.Gettext, locale)
+        conn
+
+      false ->
+        redirect(conn, to: "/") |> halt()
+    end
+  end
+
+  defp valid_locale?(locale) do
+    Enum.member?(valid_locales(), locale)
   end
 
   defp default_locale do
+    locale_config(:default_locale)
+  end
+
+  defp valid_locales do
+    locale_config(:locales)
+  end
+
+  defp locale_config(key) do
     :school_house
     |> Application.get_env(SchoolHouseWeb.Gettext)
-    |> Keyword.get(:default_locale)
+    |> Keyword.get(key)
   end
 end

--- a/lib/school_house_web/templates/layout/_locale_menu.html.leex
+++ b/lib/school_house_web/templates/layout/_locale_menu.html.leex
@@ -1,17 +1,17 @@
 <div id="locale-menu-container" class="relative inline-block text-left" x-data="{ isOpen: false }">
-    <div>
-        <button @click=" isOpen = !isOpen" type="button" class="relative inline-flex justify-center rounded-md border-2 border-brand-purple-800 dark:border-brand-purple-200 shadow-sm px-4 py-2 bg-white dark:bg-nav-dark text-sm font-bold text-primary dark:text-primary-dark focus:outline-none focus:ring-0 hover:bg-purple hover:text-white" id="locale-menu" aria-expanded="true" aria-haspopup="true">
-            <%= current_locale() %>
-            <svg class="-mr-1 ml-2 h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-            <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
-            </svg>
-        </button>
+  <div>
+    <button @click=" isOpen = !isOpen" type="button" class="relative inline-flex justify-center rounded-md border-2 border-brand-purple-800 dark:border-brand-purple-200 shadow-sm px-4 py-2 bg-white dark:bg-nav-dark text-sm font-bold text-primary dark:text-primary-dark focus:outline-none focus:ring-0 hover:bg-purple hover:text-white" id="locale-menu" aria-expanded="true" aria-haspopup="true">
+      <%= current_locale() %>
+      <svg class="-mr-1 ml-2 h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
+      </svg>
+    </button>
+  </div>
+  <div x-cloak x-show="isOpen" @click.away=" { isOpen = false } " class="origin-top-right absolute left-0 mt-2 w-24 rounded-md shadow-lg bg-white dark:bg-nav-dark ring-1 ring-black ring-opacity-5 focus:outline-none" role="menu" aria-orientation="vertical" aria-labelledby="locale-menu">
+    <div class="py-1" role="none">
+      <%= for locale <- supported_locales() do %>
+        <%= link(locale, to: current_page_locale_path(@conn, locale), class: "block px-4 py-2 text-sm text-primary dark:text-primary-dark hover:bg-brand-gray-300 dark:hover:bg-purple-dark hover:font-bold") %>
+      <% end %>
     </div>
-    <div x-cloak x-show="isOpen" @click.away=" { isOpen = false } " class="origin-top-right absolute left-0 mt-2 w-24 rounded-md shadow-lg bg-white dark:bg-nav-dark ring-1 ring-black ring-opacity-5 focus:outline-none" role="menu" aria-orientation="vertical" aria-labelledby="locale-menu">
-        <div class="py-1" role="none">
-        <%= for locale <- supported_locales() do %>
-            <a href="<%= current_page_locale_path(@conn, locale) %>" class="block px-4 py-2 text-sm text-primary dark:text-primary-dark hover:bg-brand-gray-300 dark:hover:bg-purple-dark hover:font-bold" role="menuitem"><%= locale %></a>
-        <% end %>
-        </div>
-    </div>
+  </div>
 </div>

--- a/lib/school_house_web/templates/layout/root.html.leex
+++ b/lib/school_house_web/templates/layout/root.html.leex
@@ -6,6 +6,7 @@
     <%= csrf_meta_tag() %>
     <%= live_title_tag assigns[:page_title] || "Elixir School", suffix: " · Elixir School" %>
     <link phx-track-static rel="stylesheet" href="<%= Routes.static_path(@conn, "/css/app.css") %>"/>
+    <script phx-track-static src="<%= Routes.static_path(@conn, "/js/initialize-theme.js") %>"></script>
     <script defer phx-track-static src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
   </head>
   <body class="preload dark:bg-body-dark">

--- a/lib/school_house_web/views/html_helpers.ex
+++ b/lib/school_house_web/views/html_helpers.ex
@@ -14,7 +14,9 @@ defmodule SchoolHouseWeb.HtmlHelpers do
   end
 
   def current_page_locale_path(%{request_path: request_path}, locale) do
-    String.replace(request_path, "/#{current_locale()}", "/#{locale}", global: false)
+    request_path
+    |> String.replace(~r/^\/#{current_locale()}(\/|$)/, "/#{locale}/", global: false)
+    |> String.trim_trailing("/")
   end
 
   def friendly_version({major, minor, patch}), do: "#{major}.#{minor}.#{patch}"

--- a/lib/school_house_web/views/html_helpers.ex
+++ b/lib/school_house_web/views/html_helpers.ex
@@ -14,7 +14,7 @@ defmodule SchoolHouseWeb.HtmlHelpers do
   end
 
   def current_page_locale_path(%{request_path: request_path}, locale) do
-    String.replace(request_path, "/#{current_locale()}/", "/#{locale}/", global: false)
+    String.replace(request_path, "/#{current_locale()}", "/#{locale}", global: false)
   end
 
   def friendly_version({major, minor, patch}), do: "#{major}.#{minor}.#{patch}"

--- a/test/school_house_web/controllers/lesson_controller_test.exs
+++ b/test/school_house_web/controllers/lesson_controller_test.exs
@@ -22,5 +22,10 @@ defmodule SchoolHouseWeb.LessonControllerTest do
 
       assert body =~ "Translation unavailable"
     end
+
+    test "redirects to / for invalid locale", %{conn: conn} do
+      conn = get(conn, Routes.page_path(conn, :index, "klingon"))
+      assert redirected_to(conn) == "/"
+    end
   end
 end

--- a/test/school_house_web/views/html_helpers_test.exs
+++ b/test/school_house_web/views/html_helpers_test.exs
@@ -31,11 +31,25 @@ defmodule SchoolHouseWeb.HtmlHelpersTest do
                |> HtmlHelpers.current_page_locale_path("fr")
     end
 
+    test "returns the home page path for another locale" do
+      assert "/fr" ==
+               :get
+               |> build_conn("/es")
+               |> HtmlHelpers.current_page_locale_path("fr")
+    end
+
     test "returns the same page path for a page without locale scope" do
       assert "/blog/instrumenting-phoenix" ==
                :get
                |> build_conn("/blog/instrumenting-phoenix")
                |> HtmlHelpers.current_page_locale_path("fr")
+    end
+
+    test "doesn't break URLs starting with something similar to a locale" do
+      assert "/essential" ==
+               :get
+               |> build_conn("/essential")
+               |> HtmlHelpers.current_page_locale_path("ar")
     end
   end
 


### PR DESCRIPTION
Closes #87 & #88.

# Overview

Updated the dark mode logic to add a blocking js script until the theme is set to avoid a brief flicker of light mode on page load (when dark mode is enabled).

Also updated the set locale plug to check the given locale against the list of valid locales and redirect to the home page if the locale is not valid.

Finally, updated a helper function used by the locale menu to redirect the user to the expected locale when they click on one.

https://user-images.githubusercontent.com/1526888/126853018-46075f3d-529e-4320-b764-f03b13199ecd.mp4


