### PR TITLE
fixes invalid meta tag for csrf token

### DIFF
--- a/lib/school_house_web.ex
+++ b/lib/school_house_web.ex
@@ -37,7 +37,7 @@ defmodule SchoolHouseWeb do
 
       # Import convenience functions from controllers
       import Phoenix.Controller,
-        only: [get_flash: 1, get_flash: 2, view_module: 1, view_template: 1]
+        only: [get_csrf_token: 0, get_flash: 1, get_flash: 2, view_module: 1, view_template: 1]
 
       # Include shared imports and aliases for views
       unquote(view_helpers())

--- a/lib/school_house_web/templates/layout/root.html.leex
+++ b/lib/school_house_web/templates/layout/root.html.leex
@@ -3,7 +3,10 @@
   <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <%= csrf_meta_tag() %>
+
+    <meta charset="UTF-8">
+    <meta content="<%= get_csrf_token() %>" name="csrf-token">
+
     <%= live_title_tag assigns[:page_title] || "Elixir School", suffix: " · Elixir School" %>
     <link phx-track-static rel="stylesheet" href="<%= Routes.static_path(@conn, "/css/app.css") %>"/>
     <script phx-track-static src="<%= Routes.static_path(@conn, "/js/initialize-theme.js") %>"></script>


### PR DESCRIPTION
phoenix_html generates invalid HTML code for this meta tag. This is going to be fixed in 3.0
but in the meantime we change it in our layout to fix our most common HTML issue on the site.

https://github.com/phoenixframework/phoenix_html/issues/294

Fixing this will close 4 W3C HTML issues present in each and every page, boosting us from 0% to [67% web pages without HTML issues](https://rocketvalidator.com/s/328d31c1-0a28-423f-88dc-64c5c0d97590)!

![Captura de pantalla 2021-07-25 a las 17 45 16](https://user-images.githubusercontent.com/2629/126905048-66515d2e-b69e-4905-b2cf-9b3e716dd112.png)

Fixes #94