### PR TITLE
fixes language code for Greek

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ content:
 	rm -rf content assets/static/images
 	git clone --branch content-only-changes --single-branch --depth 1 https://github.com/elixirschool/elixirschool.git content
 	mv content/images assets/static/images
-	mv content/lessons/gr content/lessons/el
 
 build:
 	docker build .

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ content:
 	rm -rf content assets/static/images
 	git clone --branch content-only-changes --single-branch --depth 1 https://github.com/elixirschool/elixirschool.git content
 	mv content/images assets/static/images
+	mv content/lessons/gr content/lessons/el
 
 build:
 	docker build .

--- a/config/config.exs
+++ b/config/config.exs
@@ -33,7 +33,7 @@ config :phoenix, :json_library, Jason
 
 config :school_house, SchoolHouseWeb.Gettext,
   default_locale: "en",
-  locales: ~w(ar bg bn de en es fr el id it ja ko ms no pl pt ru sk ta th tr uk vi zh-hans zh-hant)
+  locales: ~w(ar bg bn de el en es fr id it ja ko ms no pl pt ru sk ta th tr uk vi zh-hans zh-hant)
 
 import_config "lessons.exs"
 import_config "redirects.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -33,7 +33,7 @@ config :phoenix, :json_library, Jason
 
 config :school_house, SchoolHouseWeb.Gettext,
   default_locale: "en",
-  locales: ~w(ar bg bn de en es fr gr id it ja ko ms no pl pt ru sk ta th tr uk vi zh-hans zh-hant)
+  locales: ~w(ar bg bn de en es fr el id it ja ko ms no pl pt ru sk ta th tr uk vi zh-hans zh-hant)
 
 import_config "lessons.exs"
 import_config "redirects.exs"

--- a/config/redirects.exs
+++ b/config/redirects.exs
@@ -7,5 +7,6 @@ config :school_house,
     ~r/^\/cb/ => "/zh-hans",
     ~r/^\/tw/ => "/zh-hant",
     ~r/^\/my/ => "/me",
-    ~r/^\/jp/ => "/ja"
+    ~r/^\/jp/ => "/ja",
+    ~r/^\/gr/ => "/el"
   }


### PR DESCRIPTION
According to 

https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes

the correct 2 letter code for modern Greek is `el`, not `gr`

@doomspork maybe this should be fixed also in the main repo so when we copy content, we rename the `gr` folder to `el`. I've already done that on the Makefile, so removing the `content` folder and running `make content` again also works.

closes #97

