### PR TITLE
Fix Bug Where Querying Basics Lesson Raises Error

### DIFF
--- a/config/lessons.exs
+++ b/config/lessons.exs
@@ -52,7 +52,7 @@ config :school_house,
       :basics,
       :changesets,
       :associations,
-      :query_basics,
+      :querying_basics,
       :query_advanced
     ],
     storage: [

--- a/config/lessons.exs
+++ b/config/lessons.exs
@@ -53,7 +53,7 @@ config :school_house,
       :changesets,
       :associations,
       :querying_basics,
-      :query_advanced
+      :querying_advanced
     ],
     storage: [
       :ets,


### PR DESCRIPTION
# Overview

Closes #96 .

Updated the lessons config file to use the expected name of the lesson for ecto querying basics.

<img width="1438" alt="Screen Shot 2021-07-25 at 3 13 03 PM" src="https://user-images.githubusercontent.com/1526888/126913678-69d0e715-1747-4447-9e97-1c634009b0a4.png">

