### PR TITLE
adds missing id for country select in conferences page

### DIFF
--- a/lib/school_house_web/live/conferences_live.html.leex
+++ b/lib/school_house_web/live/conferences_live.html.leex
@@ -21,7 +21,7 @@
       </div>
       <div class="ml-auto">
         <label for="country-select" class="pr-2">Country</label>
-        <%= select f, :country, @country_options, selected: country_filter(@filters), class: "w-40 pl-3 pr-6 appearance-none bg-nav dark:bg-nav-dark" %>
+        <%= select f, :country, @country_options, selected: country_filter(@filters), class: "w-40 pl-3 pr-6 appearance-none bg-nav dark:bg-nav-dark", id: "country-select" %>
       </div>
     </form>
     <div>


### PR DESCRIPTION
This PR fixes the conference page, where the country select lacked an ID, making the `label for="country-select"` invalid as it could not be linked to the input.

Caught in https://rocketvalidator.com/s/624562a6-bdbe-4411-9c28-3652a4887982/i/112979562