### PR TITLE
404 for invalid locale

### DIFF
--- a/lib/school_house_web/plugs/set_locale_plug.ex
+++ b/lib/school_house_web/plugs/set_locale_plug.ex
@@ -3,8 +3,8 @@ defmodule SchoolHouseWeb.SetLocalePlug do
   Set the process' locale given the path params value
   """
 
-  import Phoenix.Controller, only: [redirect: 2]
-  import Plug.Conn, only: [halt: 1]
+  import Plug.Conn, only: [put_status: 2, halt: 1]
+  import Phoenix.Controller, only: [put_view: 2, render: 2]
 
   @spec init(any) :: any
   def init(opts), do: opts
@@ -19,7 +19,11 @@ defmodule SchoolHouseWeb.SetLocalePlug do
         conn
 
       false ->
-        redirect(conn, to: "/") |> halt()
+        conn
+        |> put_status(404)
+        |> put_view(SchoolHouseWeb.ErrorView)
+        |> render("404.html")
+        |> halt()
     end
   end
 

--- a/test/school_house_web/controllers/lesson_controller_test.exs
+++ b/test/school_house_web/controllers/lesson_controller_test.exs
@@ -23,9 +23,11 @@ defmodule SchoolHouseWeb.LessonControllerTest do
       assert body =~ "Translation unavailable"
     end
 
-    test "redirects to / for invalid locale", %{conn: conn} do
+    test "renders 404 for invalid locale", %{conn: conn} do
       conn = get(conn, Routes.page_path(conn, :index, "klingon"))
-      assert redirected_to(conn) == "/"
+      body = html_response(conn, 404)
+
+      assert body =~ "Page not found"
     end
   end
 end


### PR DESCRIPTION
We're currently redirecting URLs with bad locales to the front page, but this is bad because it's hiding us broken links.

Redirections should be handled for old URLs that have changed, for example with the Greek lessons:

https://beta.elixirschool.com/gr/basics/collections is redirected to https://beta.elixirschool.com/el/basics/collections

But, invalid URLs like https://beta.elixirschool.com/advanced/ar should not be redirected, they should return a 404 page so we can know there's a broken link somewhere.