### PR TITLE
adds missing alt for images in podcasts page

### DIFF
--- a/lib/school_house_web/templates/page/podcasts.html.eex
+++ b/lib/school_house_web/templates/page/podcasts.html.eex
@@ -21,7 +21,7 @@
             <div class="space-y-4">
               <a href="<%= podcast.website %>" target="_blank">
                 <div class="aspect-w-3 aspect-h-2">
-                  <img class="object-scale-down rounded-lg shadow-lg" src="<%= Routes.static_path(@conn, "/images/#{podcast.logo}") %>" alt="">
+                  <img class="object-scale-down rounded-lg shadow-lg" src="<%= Routes.static_path(@conn, "/images/#{podcast.logo}") %>" alt="<%= podcast.name %> logo">
                 </div>
               </a>
               <div class="font-medium text-md leading-6 space-y-1">


### PR DESCRIPTION
These images were missing an `alt` attribute to describe them, this fixes most of the issues in

https://rocketvalidator.com/s/7bc5b3d4-f96c-4aa5-aeae-7c5fab2d6560/v/15067194

The rest are missing alts in [this blog post](https://beta.elixirschool.com/blog/elixir-conf-eu-2019-review) will be fixed in the content repo.