### PR TITLE
Add Sitemap Links for Dark Mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ erl_crash.dump
 /assets/static/images
 /assets/static/feed.xml
 /assets/static/sitemap.xml
+/assets/static/sitemap_dark_mode.xml
 
 ### Elixir Patch ###
 
@@ -42,7 +43,8 @@ erl_crash.dump
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
+
 
 # Thumbnails
 ._*

--- a/lib/mix/tasks/school_house.gen.sitemap.ex
+++ b/lib/mix/tasks/school_house.gen.sitemap.ex
@@ -9,58 +9,69 @@ defmodule Mix.Tasks.SchoolHouse.Gen.Sitemap do
   alias SchoolHouseWeb.{Endpoint, Router.Helpers}
 
   @destination "assets/static/sitemap.xml"
+  @destination_dark_mode "assets/static/sitemap_dark_mode.xml"
 
   def run(_args) do
     Mix.Task.run("app.start")
 
     links =
-      all_links()
+      all_links(:light)
       |> Enum.map(&link_xml/1)
       |> Enum.join()
 
-    document = """
+    dark_mode_links =
+      all_links(:dark)
+      |> Enum.map(&link_xml/1)
+      |> Enum.join()
+
+    File.write!(@destination, generate_document(links))
+    File.write!(@destination_dark_mode, generate_document(dark_mode_links))
+  end
+
+  defp generate_document(links) do
+    """
     <?xml version="1.0" encoding="UTF-8" ?>
     <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
     #{links}
     </urlset>
     """
-
-    File.write!(@destination, document)
   end
 
   defp link_xml(url), do: "<url><loc>#{url}</loc></url>"
 
-  defp all_links do
-    [
-      Helpers.post_url(Endpoint, :index),
-      Helpers.page_url(Endpoint, :privacy)
-    ] ++ post_links() ++ Enum.flat_map(supported_locales(), &locale_links/1)
+  defp all_links(theme) do
+    top_level_pages = [{:post, :index}, {:page, :privacy}]
+
+    Enum.map(top_level_pages, &create_helper_link(&1, theme)) ++
+      post_links(theme) ++ Enum.flat_map(supported_locales(), &locale_links(&1, theme))
   end
 
-  defp locale_links(locale), do: page_links(locale) ++ lesson_links(locale)
+  defp locale_links(locale, theme), do: page_links(locale, theme) ++ lesson_links(locale, theme)
 
-  defp page_links(locale) do
-    [
-      Helpers.live_url(Endpoint, SchoolHouseWeb.ConferencesLive, locale),
-      Helpers.page_url(Endpoint, :index, locale),
-      Helpers.page_url(Endpoint, :podcasts, locale),
-      Helpers.page_url(Endpoint, :why, locale),
-      Helpers.page_url(Endpoint, :get_involved, locale),
-      Helpers.report_url(Endpoint, :index, locale)
+  defp page_links(locale, theme) do
+    pages = [
+      {:live, SchoolHouseWeb.ConferencesLive},
+      {:page, :index},
+      {:page, :podcasts},
+      {:page, :why},
+      {:page, :get_involved},
+      {:report, :index}
     ]
+
+    Enum.map(pages, &create_helper_link(&1, locale, theme))
   end
 
-  defp lesson_links(locale) do
+  defp lesson_links(locale, theme) do
     config = Application.get_env(:school_house, :lessons)
 
     translated_lesson_links =
       for {section, lessons} <- config, lesson <- lessons, translated_lesson?(section, lesson, locale) do
-        Helpers.lesson_url(Endpoint, :lesson, locale, section, lesson)
+        apply_theme(theme, &Helpers.lesson_url/6, [Endpoint, :lesson, locale, section, lesson])
       end
 
     section_indexes =
       for section <- Keyword.keys(config) do
-        Helpers.lesson_url(Endpoint, :index, locale, section)
+        apply_theme(theme, &Helpers.lesson_url/5, [Endpoint, :index, locale, section])
       end
 
     section_indexes ++ translated_lesson_links
@@ -73,15 +84,45 @@ defmodule Mix.Tasks.SchoolHouse.Gen.Sitemap do
     end
   end
 
-  defp post_links do
+  defp post_links(theme) do
     0..(Posts.pages() - 1)
     |> Enum.flat_map(&Posts.page/1)
-    |> Enum.map(&Helpers.post_url(Endpoint, :show, &1.slug))
+    |> Enum.map(fn post ->
+      apply_theme(theme, &Helpers.post_url/4, [Endpoint, :show, post.slug])
+    end)
   end
 
   defp supported_locales do
     :school_house
     |> Application.get_env(SchoolHouseWeb.Gettext)
     |> Keyword.get(:locales)
+  end
+
+  defp create_helper_link({:page, page}, theme) do
+    apply_theme(theme, &Helpers.page_url/3, [Endpoint, page])
+  end
+
+  defp create_helper_link({:post, page}, theme) do
+    apply_theme(theme, &Helpers.post_url/3, [Endpoint, page])
+  end
+
+  defp create_helper_link({:page, page}, locale, theme) do
+    apply_theme(theme, &Helpers.page_url/4, [Endpoint, page, locale])
+  end
+
+  defp create_helper_link({:live, page}, locale, theme) do
+    apply_theme(theme, &Helpers.live_url/4, [Endpoint, page, locale])
+  end
+
+  defp create_helper_link({:report, page}, locale, theme) do
+    apply_theme(theme, &Helpers.report_url/4, [Endpoint, page, locale])
+  end
+
+  defp apply_theme(:dark, routes_helper_fn, args) do
+    apply(routes_helper_fn, args ++ [[ui: :dark]])
+  end
+
+  defp apply_theme(:light, routes_helper_fn, args) do
+    apply(routes_helper_fn, args ++ [[]])
   end
 end

--- a/lib/school_house_web/endpoint.ex
+++ b/lib/school_house_web/endpoint.ex
@@ -25,7 +25,7 @@ defmodule SchoolHouseWeb.Endpoint do
     at: "/",
     from: :school_house,
     gzip: false,
-    only: ~w(css fonts images js favicon.ico robots.txt feed.xml sitemap.xml)
+    only: ~w(css fonts images js favicon.ico robots.txt feed.xml sitemap.xml sitemap_dark_mode.xml)
 
   # Code reloading can be explicitly enabled under the
   # :code_reloader configuration of your endpoint.

--- a/lib/school_house_web/templates/layout/root.html.leex
+++ b/lib/school_house_web/templates/layout/root.html.leex
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="<%= current_locale() %>" class=" <%= render_dark_mode?(@conn) %>">
+<html lang="<%= current_locale() %>" class="<%= render_dark_mode?(@conn) %>">
   <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>

--- a/lib/school_house_web/templates/layout/root.html.leex
+++ b/lib/school_house_web/templates/layout/root.html.leex
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="<%= current_locale() %>">
+<html lang="<%= current_locale() %>" class=" <%= get_dark_mode_param(@conn) %>">
   <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>

--- a/lib/school_house_web/templates/layout/root.html.leex
+++ b/lib/school_house_web/templates/layout/root.html.leex
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="<%= current_locale() %>" class=" <%= get_dark_mode_param(@conn) %>">
+<html lang="<%= current_locale() %>" class=" <%= render_dark_mode?(@conn) %>">
   <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>

--- a/lib/school_house_web/views/layout_view.ex
+++ b/lib/school_house_web/views/layout_view.ex
@@ -1,7 +1,7 @@
 defmodule SchoolHouseWeb.LayoutView do
   use SchoolHouseWeb, :view
 
-  def get_dark_mode_param(conn) do
+  def render_dark_mode?(conn) do
     case Map.get(conn.query_params, "ui", nil) do
       "dark" -> "dark"
       _ -> ""

--- a/lib/school_house_web/views/layout_view.ex
+++ b/lib/school_house_web/views/layout_view.ex
@@ -1,3 +1,10 @@
 defmodule SchoolHouseWeb.LayoutView do
   use SchoolHouseWeb, :view
+
+  def get_dark_mode_param(conn) do
+    case Map.get(conn.query_params, "ui", nil) do
+      "dark" -> "dark"
+      _ -> ""
+    end
+  end
 end

--- a/test/school_house_web/views/layout_view_test.exs
+++ b/test/school_house_web/views/layout_view_test.exs
@@ -1,8 +1,17 @@
 defmodule SchoolHouseWeb.LayoutViewTest do
   use SchoolHouseWeb.ConnCase, async: true
 
-  # When testing helpers, you may want to import Phoenix.HTML and
-  # use functions such as safe_to_string() to convert the helper
-  # result into an HTML string.
-  # import Phoenix.HTML
+  describe "render_dark_mode?/1" do
+    test "returns `dark` when dark mode query parameter is present", %{conn: conn} do
+      assert conn
+             |> Map.put(:query_params, %{"ui" => "dark"})
+             |> SchoolHouseWeb.LayoutView.render_dark_mode?() == "dark"
+    end
+
+    test "returns `` when dark mode query parameter is not present", %{conn: conn} do
+      assert conn
+             |> Map.put(:query_params, %{})
+             |> SchoolHouseWeb.LayoutView.render_dark_mode?() == ""
+    end
+  end
 end


### PR DESCRIPTION
# Overview 

Related to #109 .

Added another sitemap file for dark mode so that Rocket Validator can validate accessibility of dark mode as well.

I am open to suggestions on this, but to handle the `ui` query parameter I added a function to `LayoutView` which I use inside the `root.html.eex` file.