### PR TITLE
Only Attempt a Deploy When Main Repo is Updated

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ on:
       - master
 jobs:
   build:
+    if: ${{ github.repository_owner == 'elixirschool' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
# Overview
Updated the deploy.yml workflow to only attempt the deploy job when the repo is the original elixirschool instance and not a fork.

This fixes an issue where Github actions attempts to deploy code in forked repos and sends a somewhat confusing failure email when the deploy fails.