### PR TITLE
Update Color Scheme on Report Page

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -217,7 +217,7 @@ input:checked ~ .dot {
   color: #d14;
 }
 .makeup .sr {
-  color: #009926;
+  color: #008521;
 }
 .makeup .s1 {
   color: #d14;

--- a/lib/school_house_web/templates/report/_lesson.html.eex
+++ b/lib/school_house_web/templates/report/_lesson.html.eex
@@ -1,14 +1,14 @@
 <tr class="<%= translation_status_css_class(@line) %>">
-  <td class="px-6 py-4 text-sm font-medium text-heavy dark:text-heavy-dark whitespace-nowrap">
+  <td class="px-6 py-4 text-sm font-medium text-heavy whitespace-nowrap">
     <%= @line.original.title %>
   </td>
-  <td class="px-6 py-4 text-sm text-primary dark:text-primary-dark whitespace-nowrap">
+  <td class="px-6 py-4 text-sm text-heavy whitespace-nowrap">
     <%= @line.lesson.title %>
   </td>
-  <td class="px-6 py-4 text-sm text-primary dark:text-primary-dark whitespace-nowrap">
+  <td class="px-6 py-4 text-sm text-heavy whitespace-nowrap">
     <%= friendly_version(@line.original.version) %>
   </td>
-  <td class="px-6 py-4 text-sm text-primary dark:text-primary-dark whitespace-nowrap">
+  <td class="px-6 py-4 text-sm text-heavy whitespace-nowrap">
     <%= friendly_version(@line.lesson.version) %>
   </td>
 </tr>

--- a/lib/school_house_web/templates/report/_missing.html.eex
+++ b/lib/school_house_web/templates/report/_missing.html.eex
@@ -1,12 +1,12 @@
-<tr class="bg-red-500">
-  <td class="px-6 py-4 text-sm font-medium text-heavy dark:text-heavy-dark whitespace-nowrap">
+<tr class="bg-red-300">
+  <td class="px-6 py-4 text-sm font-medium text-heavy whitespace-nowrap">
     <%= @line.original.title %>
   </td>
-  <td class="px-6 py-4 text-sm text-primary dark:text-primary-dark whitespace-nowrap">
+  <td class="px-6 py-4 text-sm text-primary whitespace-nowrap">
   </td>
-  <td class="px-6 py-4 text-sm text-primary dark:text-primary-dark whitespace-nowrap">
+  <td class="px-6 py-4 text-sm text-primary whitespace-nowrap">
     <%= friendly_version(@line.original.version) %>
   </td>
-  <td class="px-6 py-4 text-sm text-primary dark:text-primary-dark whitespace-nowrap">
+  <td class="px-6 py-4 text-sm text-primary whitespace-nowrap">
   </td>
 </tr>

--- a/lib/school_house_web/templates/report/_section.html.eex
+++ b/lib/school_house_web/templates/report/_section.html.eex
@@ -8,9 +8,9 @@
 
 <div class="flex flex-col">
   <div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
-    <div class="overflow-hidden border-b border-gray-200 shadow sm:rounded-lg">
-      <table class="min-w-full divide-y divide-gray-200">
-        <thead class="bg-gray-50">
+    <div class="overflow-hidden border-b dark:border-gray-500 border-gray-200 shadow-md sm:rounded-lg">
+      <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-500">
+        <thead class="bg-gray-200 dark:bg-gray-800">
           <tr>
             <th scope="col" class="px-6 py-3 text-xs font-medium tracking-wider text-left uppercase text-primary dark:text-primary-dark">
               <%= gettext("Lesson") %>

--- a/lib/school_house_web/templates/report/report.html.eex
+++ b/lib/school_house_web/templates/report/report.html.eex
@@ -1,9 +1,9 @@
 <div class="py-12 bg-body dark:bg-body-dark">
   <div class="px-4 mx-auto max-w-7xl sm:px-6 lg:px-8">
     <div class="lg:text-center">
-      <p class="mt-2 text-4xl font-extrabold tracking-tight leading-8 text-purple dark:text-purple-dark sm:text-4xl">
+      <h1 class="mt-2 text-4xl font-extrabold tracking-tight leading-8 text-purple dark:text-purple-dark sm:text-4xl">
       <%= gettext("Translation Report") %>
-      </p>
+      </h1>
     </div>
   </div>
 </div>

--- a/lib/school_house_web/views/html_helpers.ex
+++ b/lib/school_house_web/views/html_helpers.ex
@@ -48,8 +48,8 @@ defmodule SchoolHouseWeb.HtmlHelpers do
   end
 
   def translation_status_css_class(%{status: :complete}), do: "bg-green-500"
-  def translation_status_css_class(%{status: status}) when status in [:major, :missing], do: "bg-red-500"
-  def translation_status_css_class(%{status: :minor}), do: "bg-yellow-500"
+  def translation_status_css_class(%{status: status}) when status in [:major, :missing], do: "bg-yellow-500"
+  def translation_status_css_class(%{status: :minor}), do: "bg-yellow-400"
   def translation_status_css_class(%{status: :patch}), do: "bg-yellow-200"
   def translation_status_css_class(_line), do: "bg-white"
 end


### PR DESCRIPTION
# Overview
Addresses #123 

Updated report page to use colors with higher contrast in light mode and dark mode.

## Screenshots
<img width="1434" alt="Screen Shot 2021-08-09 at 5 45 28 PM" src="https://user-images.githubusercontent.com/1526888/128787994-baeeb662-635a-4704-82a8-bf866027b90b.png">
<img width="1433" alt="Screen Shot 2021-08-09 at 5 45 49 PM" src="https://user-images.githubusercontent.com/1526888/128787997-9216d949-a15c-4049-95a9-869fd80d6299.png">
