### PR TITLE
Fix Remaining Contrast Issues for Dark Theme

### DIFF
--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -170,6 +170,9 @@ module.exports = {
                         },
                         blockquote: {
                             color: theme('colors.brand-gray-300')
+                        },
+                        thead: {
+                            color: theme('colors.brand-gray-300')
                         }
                     }
                 }

--- a/lib/school_house_web/templates/lesson/_testing.html.eex
+++ b/lib/school_house_web/templates/lesson/_testing.html.eex
@@ -4,7 +4,7 @@
       <p class="mt-2 text-4xl font-extrabold tracking-tight leading-8 text-purple dark:text-purple-dark sm:text-4xl">
       <%= gettext("Lessons") %>: <%= gettext("Testing") %>
       </p>
-      <p class="max-w-2xl mt-4 text-xl text-lighter dark:text-lighter-dark lg:mx-auto">
+      <p class="max-w-2xl mt-4 text-xl text-light dark:text-light-dark lg:mx-auto">
       <%= gettext("The first step to writing fault tolerant and scalable code is writing bug free code. In these lessons we explore how best to test our Elixir code.") %>
       </p>
     </div>

--- a/lib/school_house_web/templates/page/_newsletter.html.eex
+++ b/lib/school_house_web/templates/page/_newsletter.html.eex
@@ -12,7 +12,7 @@
       <div class="mt-12 sm:w-full sm:max-w-md lg:mt-0 lg:ml-8 lg:flex-1">
         <form class="sm:flex">
           <label for="emailAddress" class="sr-only">Email address</label>
-          <input id="emailAddress" name="emailAddress" type="email" autocomplete="email" required class="w-full px-5 py-3 placeholder-gray-500 border-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-indigo-700 focus:ring-white rounded-md" placeholder="Enter your email">
+          <input id="emailAddress" name="emailAddress" type="email" autocomplete="email" required class="w-full px-5 py-3 dark:text-gray-600 placeholder-gray-500 border-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-indigo-700 focus:ring-white rounded-md" placeholder="Enter your email">
           <button type="submit" class="flex items-center justify-center w-full px-5 py-3 mt-3 text-base font-medium text-white border border-transparent rounded-md bg-brand-red-500 hover:bg-indigo-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-indigo-700 focus:ring-white sm:mt-0 sm:ml-3 sm:w-auto sm:flex-shrink-0">
             Notify me
           </button>


### PR DESCRIPTION
# Overview

In the latest Rocket Validator report, there are only a [handful of color contrast issues](https://rocketvalidator.com/s/02e7c5f0-2887-47db-9e5c-f75543b80276/v/15180463) remaining for the dark theme UI. This pr should fix those!

For the light theme, the [only color contrast issue](https://rocketvalidator.com/s/5517fb81-fa1c-4cc9-a4c4-201426d8db9f/v/15179966) occurs on a page we do not have control over and does not contain critical content so I think it is worth removing that page from the report altogether: https://beta.elixirschool.com/cdn-cgi/l/email-protection .

Once this is merged, we should run one more report @jaimeiniesta and then 🤞🏼 finally be able to close #109 !

## Screenshots

### Previously the table header color was black

#### Before
<img width="1175" alt="Screen Shot 2021-08-16 at 10 34 04 AM" src="https://user-images.githubusercontent.com/1526888/129598109-946d9128-0778-4378-b185-951d7dd82d6f.png">

#### After
<img width="1060" alt="Screen Shot 2021-08-16 at 8 42 20 AM" src="https://user-images.githubusercontent.com/1526888/129585688-cea27f9e-bfbe-4066-a807-b5c50707d5a2.png">

### Previously the description text was light gray

#### Before
<img width="1433" alt="Screen Shot 2021-08-16 at 10 34 54 AM" src="https://user-images.githubusercontent.com/1526888/129598209-746dd363-255d-44ef-ae5c-3c6b0b35cbd0.png">

#### After
<img width="1428" alt="Screen Shot 2021-08-16 at 8 41 45 AM" src="https://user-images.githubusercontent.com/1526888/129585691-2efc77b2-13db-4980-8051-5b2145d3bb56.png">

### Previously the input text color was very light

#### Before
<img width="1314" alt="Screen Shot 2021-08-16 at 10 36 00 AM" src="https://user-images.githubusercontent.com/1526888/129598345-235549c8-64cf-4aaf-bd94-c7e81b3f1bc7.png">


#### After
<img width="1435" alt="Screen Shot 2021-08-16 at 8 41 25 AM" src="https://user-images.githubusercontent.com/1526888/129585692-4d567191-1e43-42a3-b418-8beef2b054ae.png">

