### PR TITLE
Remove Extra Paragraph Tag from Lesson Section Index Page

### DIFF
--- a/lib/school_house_web/templates/lesson/index.html.eex
+++ b/lib/school_house_web/templates/lesson/index.html.eex
@@ -7,9 +7,7 @@
         <%= lesson_link(@conn, lesson.section, lesson.name, "text-lg font-medium leading-6 text-purple dark:text-purple-dark") do %>
           <%= lesson.title %>
         <% end %>
-        <p class="max-w-2xl px-4 mt-1 text-sm">
           <%= raw lesson.excerpt %>
-        </p>
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
# Overview

Removes extra `<p>` tag in the lessons index page. This was causing an HTML validation error in Rocket Validator.

Closes #128 