### PR TITLE
Update Excerpt Link Color, Code Blocks

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -80,11 +80,14 @@ input:checked ~ .dot {
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 section.lesson-pagination p.excerpt {
   font-size: 0.9rem;
-  opacity: 0.8;
 }
 
 .excerpt-box > p {
   margin: 0;
+}
+
+p.excerpt > a {
+  color: #776C84;
 }
 
 .makeup .hll {background-color: #f4f5f6}

--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -93,7 +93,9 @@ module.exports = {
                         maxWidth: 'inherit',
                         pre: {
                             'background-color': theme('colors.brand-gray-100'),
-                            color: theme('colors.brand-gray-700')
+                            color: theme('colors.brand-gray-700'),
+                            'overflow-x': 'auto',
+                            width: '100%'
                         },
                         h1: {
                             color: theme('colors.brand-gray-750'),

--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -93,9 +93,7 @@ module.exports = {
                         maxWidth: 'inherit',
                         pre: {
                             'background-color': theme('colors.brand-gray-100'),
-                            color: theme('colors.brand-gray-700'),
-                            'overflow-x': 'auto',
-                            width: '100%'
+                            color: theme('colors.brand-gray-700')
                         },
                         h1: {
                             color: theme('colors.brand-gray-750'),


### PR DESCRIPTION
# Overview

This pr updates the link color used in excerpt blocks on lesson pages to have better color contrast.

I tried to grab a before and after report on Rocket Validator, but when I ran a report on an individual [page from the report that reported the contrast issue](https://rocketvalidator.com/s/77b28abc-4e56-4d0a-83fc-51f77e0ccf1a/p/4834495/v?search=Elements+must+have+sufficient+color+contrast), Rocket Validator [found no accessibility issues](https://rocketvalidator.com/s/3c4918e7-623b-4334-8ccb-22bb482528ac) on the same page on the beta site.