### PR TITLE
The existing site includes /lessons

### DIFF
--- a/lib/school_house_web/router.ex
+++ b/lib/school_house_web/router.ex
@@ -36,8 +36,8 @@ defmodule SchoolHouseWeb.Router do
 
       get "/report", ReportController, :index
 
-      get "/:section", LessonController, :index
-      get "/:section/:name", LessonController, :lesson
+      get "/lessons/:section", LessonController, :index
+      get "/lessons/:section/:name", LessonController, :lesson
     end
   end
 


### PR DESCRIPTION
This is what the current site uses and it's 404ing breaking people's links: https://elixirschool.com/en/lessons/basics/basics/