### PR TITLE
Update Phoenix Host to Remove Beta Subdomain

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
     "name": "Elixir School House",
-    "website": "https://beta.elixirschool.com/",
+    "website": "https://elixirschool.com/",
     "repository": "https://github.com/elixirschool/school_house",
     "stack": "container"
 }

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -10,7 +10,7 @@ use Mix.Config
 # before starting your production server.
 config :school_house, SchoolHouseWeb.Endpoint,
   http: [port: {:system, "PORT"}],
-  url: [scheme: "https", host: "beta.elixirschool.com", port: 443],
+  url: [scheme: "https", host: "elixirschool.com", port: 443],
   cache_static_manifest: "priv/static/cache_manifest.json"
 
 # Do not print debug messages in production

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -16,7 +16,7 @@ live_view_salt =
 
 host =
   case System.get_env("HEROKU_APP_NAME") do
-    nil -> "beta.elixirschool.com"
+    nil -> "elixirschool.com"
     sub -> "#{sub}.herokuapp.com"
   end
 


### PR DESCRIPTION
# Overview

Should resolve #143.

Now that we are no longer in beta we don't need to prefix elixirschool.com with beta 🎉 