### PR TITLE
Add pagination to blog posts page

### DIFF
--- a/lib/school_house_web/templates/post/index.html.heex
+++ b/lib/school_house_web/templates/post/index.html.heex
@@ -18,3 +18,13 @@
     <% end %>
   </div>
 </div>
+
+<%= if @conn.assigns.page_title == "Blog" do %>
+  <div class="p-4 mt-12 border-t">
+    <%= for page <- 1..@pages do %>
+      <%= link(to: Routes.post_path(@conn, :index, page: (page - 1)), class: "inline-flex items-center px-4 py-2 border text-sm font-medium rounded-md") do %>
+        <%= page %>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/lib/school_house_web/templates/post/index.html.heex
+++ b/lib/school_house_web/templates/post/index.html.heex
@@ -20,11 +20,13 @@
 </div>
 
 <%= if @conn.assigns.page_title == "Blog" do %>
-  <div class="p-4 mt-12 border-t">
-    <%= for page <- 1..@pages do %>
-      <%= link(to: Routes.post_path(@conn, :index, page: (page - 1)), class: "inline-flex items-center px-4 py-2 border text-sm font-medium rounded-md") do %>
-        <%= page %>
+  <div class="flex justify-center">
+    <div class="p-4 mt-12 border-b">
+      <%= for page <- 1..@pages do %>
+        <%= link(to: Routes.post_path(@conn, :index, page: (page - 1)), class: "inline-flex items-center px-4 py-2 border text-sm font-medium rounded-md") do %>
+          <%= page %>
+        <% end %>
       <% end %>
-    <% end %>
+    </div>
   </div>
 <% end %>


### PR DESCRIPTION
This PR solves #148

This should be seen as a temporary solution. I think it’s worth the price fix the access to the older posts as soon as possible even with a not so elegant solution.
I will work on a more complete solution that allows readers to choose items per page, with pagination working with tags too, an improved and responsive design and a more organized code.