### PR TITLE
Wrong URL to edit lessons

### DIFF
--- a/lib/school_house_web/templates/lesson/lesson.html.heex
+++ b/lib/school_house_web/templates/lesson/lesson.html.heex
@@ -17,7 +17,7 @@
 
   <blockquote class="edit-lesson dark:text-primary-dark">
     Caught a mistake or want to contribute to the lesson?
-    <a href={"https://github.com/elixirschool/elixirschool/edit/master/#{@lesson.locale}/lessons/#{@lesson.section}/#{@lesson.name}.md"} target="_blank" rel="noopener">
+    <a href={"https://github.com/elixirschool/elixirschool/edit/master/lessons/#{@lesson.locale}/#{@lesson.section}/#{@lesson.name}.md"} target="_blank" rel="noopener">
       Edit this lesson on GitHub!
     </a>
   </blockquote>


### PR DESCRIPTION
The URL was pointing to the wrong place. the path `lessons` should be before the location.