### PR TITLE
Fix typos in lesson links

### DIFF
--- a/lib/school_house_web/templates/layout/_lesson_menu.html.heex
+++ b/lib/school_house_web/templates/layout/_lesson_menu.html.heex
@@ -143,7 +143,7 @@
                         <% end %>
                     </li>
                     <li>
-                        <%= lesson_link @conn, :advanced, :mtaprogramming do %>
+                        <%= lesson_link @conn, :advanced, :metaprogramming do %>
                             <%= gettext("Metaprogramming") %>
                         <% end %>
                     </li>
@@ -153,7 +153,7 @@
                         <% end %>
                     </li>
                     <li>
-                        <%= lesson_link @conn, :advanced, :typespecs do %>
+                        <%= lesson_link @conn, :advanced, :typespec do %>
                             <%= gettext("Specifications and types") %>
                         <% end %>
                     </li>


### PR DESCRIPTION
This PR resolves the issues with lesson links mentioned in #151.