### PR TITLE
fix nav bar height

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -43,6 +43,7 @@ Influenced by: https://sproutsocial.com/
   padding-left: 6px;
   position: relative;
   top: -1px;
+  line-height: 1;
 }
 
 .toggle-input {
@@ -63,10 +64,6 @@ Influenced by: https://sproutsocial.com/
 
 .toggle-input:checked ~ label:after {
   content: "\25B2";
-  font-size: 10px;
-  padding-left: 6px;
-  position: relative;
-  top: -1px;
 }
 
 /* #slider Class Styles


### PR DESCRIPTION
this fixes the "Lessons" toggle being slightly taller than the other links, noticeable when hovering over links with the toggle menu open:
![image](https://user-images.githubusercontent.com/7574985/136183469-860fc686-ab90-4f5e-be1c-b050dc548f73.png)

The cause is the toggle arrow missing a specified `line-height`.