### PR TITLE
bold current lesson in menu

### DIFF
--- a/lib/school_house_web/views/html_helpers.ex
+++ b/lib/school_house_web/views/html_helpers.ex
@@ -30,7 +30,12 @@ defmodule SchoolHouseWeb.HtmlHelpers do
       ) do
     {destination, additional_classes} =
       if Lessons.exists?(section, name, current_locale()) do
-        {Routes.lesson_path(conn, :lesson, current_locale(), section, name), ""}
+        path = Routes.lesson_path(conn, :lesson, current_locale(), section, name)
+        if path == Phoenix.Controller.current_path(conn, %{}) do
+          {path, "font-bold"}
+        else
+          {path, ""}
+        end
       else
         {"#", "cursor-not-allowed"}
       end


### PR DESCRIPTION
visual indication of current page in the lessons menu to improve navigation 🙂 (the old layout changed the color of the lesson listing)

![image](https://user-images.githubusercontent.com/7574985/136220075-7d7fbe27-22a1-491f-9601-ec65ac5560de.png) ![image](https://user-images.githubusercontent.com/7574985/136221340-b6f13d94-a4c0-48c4-87a9-5bf5efd933a2.png)

