### PR TITLE
fix header regex not recognizing bengali, tamil

### DIFF
--- a/lib/school_house/content/lesson.ex
+++ b/lib/school_house/content/lesson.ex
@@ -3,7 +3,7 @@ defmodule SchoolHouse.Content.Lesson do
   Encapsulates an individual lesson and handles parsing the originating markdown file
   """
 
-  @headers_regex ~r/<(h\d)>(["\p{L}\s?!\.\/\d]+)(?=<\/\1>)/iu
+  @headers_regex ~r/<(h\d)>(["\p{L}\p{M}\s?!\.\/\d]+)(?=<\/\1>)/iu
   @enforce_keys [:body, :section, :locale, :name, :title, :version]
 
   defstruct [


### PR DESCRIPTION
Table of contents weren't being generated for Bengali or Tamil, due to the regex for parsing headers not accounting for characters which would fall under the [Unicode general category](https://unicode.org/reports/tr18/#General_Category_Property) for marks.

I don't know Bengali, Tamil, or Unicode, so I have no idea why these languages have characters distinguished as marks but not others 🤷

I'm also not sure why the regex for recognizing headers, now `~r/<(h\d)>(["\p{L}\p{M}\s?!\.\/\d]+)(?=<\/\1>)/iu`, is so specific. Perhaps it would be good to generalize it some? Currently it wouldn't catch any _transcendent_ numerals, symbols, or punctuation (the other Unicode general categories).