### PR TITLE
fix lesson pagination causing horizontal scroll

### DIFF
--- a/lib/school_house_web/templates/layout/root.html.heex
+++ b/lib/school_house_web/templates/layout/root.html.heex
@@ -13,7 +13,7 @@
     <script defer phx-track-static src={Routes.static_path(@conn, "/assets/app.js")}></script>
     <link rel="icon" href="/favicon.ico" />
   </head>
-  <body class="preload dark:bg-body-dark">
+  <body class="preload dark:bg-body-dark overflow-x-hidden">
     <%= render "_header.html", conn: @conn %>
     <%= @inner_content %>
     <%= render "_footer.html", conn: @conn %>


### PR DESCRIPTION
Currently, the css for lesson pagination uses `width: 100vw` (`.w-screen`) to achieve full screen width as a child of a limited-width (`.container`) parent.

https://github.com/elixirschool/school_house/blob/b8b5ed30c47d59250ab7f7cbc29c61d418741732/lib/school_house_web/templates/lesson/_pagination.html.heex#L1

The problem with `100vw` is that it only works on browsers that overlay scrollbars atop the page (e.g. macOS, mobile browsers). On browsers that fit a scrollbar beside the page (e.g. Windows), the presence of a vertical scrollbar will result in the `100vw` element being wider than the page, causing an unseemly horizontal scrollbar.

![horizontal_scroll](https://user-images.githubusercontent.com/7574985/136641324-f3cbd22f-faed-4d72-8211-bc3118055b00.gif)

This is just a "quick fix" that puts `overflow-x: hidden` on `body`, which should be fine so long as the website doesn't allow `body` to ever be wider than the screen (Elixir School's current layout doesn't).