### PR TITLE
Improve Repo Hygiene

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -164,7 +164,7 @@
         {Credo.Check.Readability.ImplTrue, false},
         {Credo.Check.Readability.MultiAlias, false},
         {Credo.Check.Readability.SeparateAliasRequire, false},
-        {Credo.Check.Readability.SinglePipe, false},
+        {Credo.Check.Readability.SinglePipe, []},
         {Credo.Check.Readability.Specs, false},
         {Credo.Check.Readability.StrictModuleLayout, false},
         {Credo.Check.Readability.WithCustomTaggedTuple, false},

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ erl_crash.dump
 /rel
 /content
 /assets/static/images
+/assets/static/sitemap*
 /priv/static
 
 ### Elixir Patch ###

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ To get up and running all we need is a single command:
 $ make setup
 ```
 
-This will fetch our dependencies and setup our content from the external repository.
+This will fetch dependencies, download lessons and blog posts from the [external repository](https://github.com/elixirschool/elixirschool), and compile the project.
 
-Then start the phoenix server
+Then start the phoenix server with:
 
 ```shell
 $ mix phx.server

--- a/app.json
+++ b/app.json
@@ -1,5 +1,5 @@
 {
-    "name": "Elixir School House",
+    "name": "Elixir School",
     "website": "https://elixirschool.com/",
     "repository": "https://github.com/elixirschool/school_house",
     "stack": "container"

--- a/test/school_house/conferences_test.exs
+++ b/test/school_house/conferences_test.exs
@@ -40,7 +40,7 @@ defmodule SchoolHouse.ConferencesTest do
       us_conferences = Conferences.by_country("United States")
 
       assert 1 == length(us_conferences)
-      assert hd(us_conferences) |> Map.get(:country) == "United States"
+      assert us_conferences |> hd() |> Map.get(:country) == "United States"
     end
 
     test "returns empty array for conferences in Brazil" do


### PR DESCRIPTION
# Overview

Updated a handful of files to improve repo/dev qol:
* Enabled single pipeline rule in `.credo.exs` to enforce a stylistic rule that pops up in prs from time to time
* Added sitemap files back to the `.gitignore` since they are being generated to this location before being moved to `/priv`
* Added a link to the ElixirSchool repo in the README.md to make it more obvious where the lessons and blog posts live
* Updated the `app.json` file used by Heroku to use the correct name!

Edit: I'd be lying if I said this wasn't partially motivated by a desire to wrap up my Hacktoberfest contributions 😂 