### PR TITLE
Fix build + make it friendly for ElixirSchool contributors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ content:
 	# Clone from live repo
 	rm -rf content && git clone --branch master --single-branch --depth 1 https://github.com/elixirschool/elixirschool.git content
 
-	# If you are testing Elixir School guides, you can comment the line above and uncoment the one bellow, updating PATH_TO_YOUR_LOCAL_REPO
+	# If you are testing Elixir School guides, you can comment the line above and uncomment the one below, updating PATH_TO_YOUR_LOCAL_REPO
 	# rsync -av /PATH_TO_YOUR_LOCAL_REPO/elixirschool/ ./content --exclude .git
 
 	mv content/images assets/static/images

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,17 @@
-.PHONY: $(MAKECMDGOALS)
+.PHONY: $(MAKECMDGOALS) content
 
 setup: content
 	mix do setup, compile, assets.deploy
 
 content:
-	rm -rf content assets/static/images
-	git clone --branch master --single-branch --depth 1 https://github.com/elixirschool/elixirschool.git content
+	rm -rf assets/static/images
+
+	# Clone from live repo
+	rm -rf content && git clone --branch master --single-branch --depth 1 https://github.com/elixirschool/elixirschool.git content
+
+	# If you are testing Elixir School guides, you can comment the line above and uncoment the one bellow, updating PATH_TO_YOUR_LOCAL_REPO
+	# rsync -av /PATH_TO_YOUR_LOCAL_REPO/elixirschool/ ./content --exclude .git
+
 	mv content/images assets/static/images
 
 build:


### PR DESCRIPTION
First, it adds content as Phony, otherwise, if the folder was present it was not getting rebuilt.
Then it adapts the conetntn command for testing locally. Allowing to run `make content` and pick up the changes when running locally.