### PR TITLE
Fix Next Lesson Heading Alignment

### DIFF
--- a/lib/school_house_web/templates/lesson/_pagination.html.heex
+++ b/lib/school_house_web/templates/lesson/_pagination.html.heex
@@ -37,7 +37,7 @@
             </div>
             <div class="text-right mr-2">
               <p class="text-base font-semibold text-primary dark:text-primary-dark mb-2">
-                <%= lesson_link(@conn, @next.section, @next.name, "hover:text-primary") do %>
+                <%= lesson_link(@conn, @next.section, @next.name, "hover:text-primary ml-auto") do %>
                   <%= @next.title %>
                 <% end %>
               </p>


### PR DESCRIPTION
# Overview

This is a super small pr to fix an issue I noticed with heading alignment for the "next lesson" navigation section below each lesson.

### Before
<img width="361" alt="Screen Shot 2022-06-04 at 4 06 13 PM" src="https://user-images.githubusercontent.com/1526888/172026913-8f74a910-4641-43d5-b337-bbe69c49ee4a.png">

### After
<img width="364" alt="Screen Shot 2022-06-04 at 4 05 16 PM" src="https://user-images.githubusercontent.com/1526888/172026915-3172c1ea-a461-4c33-a24d-de53428ac2ea.png">
