### PR TITLE
feat: update all github actions with caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
             deps
       - if: steps.cache.outputs.cache-hit != 'true'
         run: mix deps.get
-      - run: mix credo
+      - run: mix dialyzer
 
   Format:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: erlef/setup-beam@v1
+      - id: beam
+        uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}
@@ -60,7 +61,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: erlef/setup-beam@v1
+      - id: beam
+        uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}
@@ -85,7 +87,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: erlef/setup-beam@v1
+      - id: beam
+        uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}
@@ -110,7 +113,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: erlef/setup-beam@v1
+      - id: beam
+        uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,11 @@ jobs:
         uses: actions/cache@v3
         with:
           key: |
-            ${{ env.CACHE_VERSION }}-{{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-credo-${{ hashFiles('mix.lock') }}-${{ github.ref }}
+            ${{ env.CACHE_VERSION }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-credo-${{ hashFiles('mix.lock') }}-${{ github.ref }}
           restore-keys: |
-            ${{ env.CACHE_VERSION }}-{{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-credo-${{ hashFiles('mix.lock') }}-${{ format('refs/heads/{0}', github.event.repository.default_branch) }}
-            ${{ env.CACHE_VERSION }}-{{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-credo-
-            ${{ env.CACHE_VERSION }}-{{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-
+            ${{ env.CACHE_VERSION }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-credo-${{ hashFiles('mix.lock') }}-${{ format('refs/heads/{0}', github.event.repository.default_branch) }}
+            ${{ env.CACHE_VERSION }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-credo-
+            ${{ env.CACHE_VERSION }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-
           path: |
             _build
             deps
@@ -70,11 +70,11 @@ jobs:
         uses: actions/cache@v3
         with:
           key: |
-            ${{ env.CACHE_VERSION }}-{{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-dialyzer-${{ hashFiles('mix.lock') }}-${{ github.ref }}
+            ${{ env.CACHE_VERSION }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-dialyzer-${{ hashFiles('mix.lock') }}-${{ github.ref }}
           restore-keys: |
-            ${{ env.CACHE_VERSION }}-{{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-dialyzer-${{ hashFiles('mix.lock') }}-${{ format('refs/heads/{0}', github.event.repository.default_branch) }}
-            ${{ env.CACHE_VERSION }}-{{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-dialyzer-
-            ${{ env.CACHE_VERSION }}-{{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-
+            ${{ env.CACHE_VERSION }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-dialyzer-${{ hashFiles('mix.lock') }}-${{ format('refs/heads/{0}', github.event.repository.default_branch) }}
+            ${{ env.CACHE_VERSION }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-dialyzer-
+            ${{ env.CACHE_VERSION }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-
           path: |
             _build
             deps
@@ -96,11 +96,11 @@ jobs:
         uses: actions/cache@v3
         with:
           key: |
-            ${{ env.CACHE_VERSION }}-{{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-format-${{ hashFiles('mix.lock') }}-${{ github.ref }}
+            ${{ env.CACHE_VERSION }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-format-${{ hashFiles('mix.lock') }}-${{ github.ref }}
           restore-keys: |
-            ${{ env.CACHE_VERSION }}-{{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-format-${{ hashFiles('mix.lock') }}-${{ format('refs/heads/{0}', github.event.repository.default_branch) }}
-            ${{ env.CACHE_VERSION }}-{{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-format-
-            ${{ env.CACHE_VERSION }}-{{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-
+            ${{ env.CACHE_VERSION }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-format-${{ hashFiles('mix.lock') }}-${{ format('refs/heads/{0}', github.event.repository.default_branch) }}
+            ${{ env.CACHE_VERSION }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-format-
+            ${{ env.CACHE_VERSION }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-
           path: |
             _build
             deps
@@ -122,11 +122,11 @@ jobs:
         uses: actions/cache@v3
         with:
           key: |
-            ${{ env.CACHE_VERSION }}-{{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-test-${{ hashFiles('mix.lock') }}-${{ github.ref }}
+            ${{ env.CACHE_VERSION }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-test-${{ hashFiles('mix.lock') }}-${{ github.ref }}
           restore-keys: |
-            ${{ env.CACHE_VERSION }}-{{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-test-${{ hashFiles('mix.lock') }}-${{ format('refs/heads/{0}', github.event.repository.default_branch) }}
-            ${{ env.CACHE_VERSION }}-{{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-test-
-            ${{ env.CACHE_VERSION }}-{{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-
+            ${{ env.CACHE_VERSION }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-test-${{ hashFiles('mix.lock') }}-${{ format('refs/heads/{0}', github.event.repository.default_branch) }}
+            ${{ env.CACHE_VERSION }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-test-
+            ${{ env.CACHE_VERSION }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-
           path: |
             _build
             deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,50 +11,122 @@ on:
     branches:
       - main
 
-jobs:
-  Test:
-    strategy:
-      matrix:
-        elixir: ['1.13']
-        otp: [25]
-    env:
-      MIX_ENV: test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: erlef/setup-beam@v1
-        with:
-          otp-version: ${{matrix.otp}}
-          elixir-version: ${{matrix.elixir}}
-      - run: mix deps.get
-      - run: mix test
+env:
+  CACHE_VERSION: v1
+  ELIXIR_VERSION: '1.13'
+  MIX_ENV: test
+  OTP_VERSION: '25'
 
-  Format:
-    strategy:
-      matrix:
-        elixir: ['1.13']
-        otp: [25]
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  Build:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v2
-      - uses: erlef/setup-beam@v1
-        with:
-          otp-version: ${{matrix.otp}}
-          elixir-version: ${{matrix.elixir}}
-      - run: mix deps.get
-      - run: mix format --check-formatted
+      - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v1
+      - uses: docker/build-push-action@v3
 
   Credo:
-    strategy:
-      matrix:
-        elixir: ['1.13']
-        otp: [25]
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: ${{matrix.otp}}
-          elixir-version: ${{matrix.elixir}}
-      - run: mix deps.get
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+      - id: cache
+        uses: actions/cache@v3
+        with:
+          key: |
+            ${{ env.CACHE_VERSION }}-{{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-credo-${{ hashFiles('mix.lock') }}-${{ github.ref }}
+          restore-keys: |
+            ${{ env.CACHE_VERSION }}-{{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-credo-${{ hashFiles('mix.lock') }}-${{ format('refs/heads/{0}', github.event.repository.default_branch) }}
+            ${{ env.CACHE_VERSION }}-{{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-credo-
+            ${{ env.CACHE_VERSION }}-{{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-
+          path: |
+            _build
+            deps
+      - if: steps.cache.outputs.cache-hit != 'true'
+        run: mix deps.get
       - run: mix credo
+
+  Dialyzer:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+      - id: cache
+        uses: actions/cache@v3
+        with:
+          key: |
+            ${{ env.CACHE_VERSION }}-{{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-dialyzer-${{ hashFiles('mix.lock') }}-${{ github.ref }}
+          restore-keys: |
+            ${{ env.CACHE_VERSION }}-{{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-dialyzer-${{ hashFiles('mix.lock') }}-${{ format('refs/heads/{0}', github.event.repository.default_branch) }}
+            ${{ env.CACHE_VERSION }}-{{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-dialyzer-
+            ${{ env.CACHE_VERSION }}-{{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-
+          path: |
+            _build
+            deps
+      - if: steps.cache.outputs.cache-hit != 'true'
+        run: mix deps.get
+      - run: mix credo
+
+  Format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+      - id: cache
+        uses: actions/cache@v3
+        with:
+          key: |
+            ${{ env.CACHE_VERSION }}-{{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-format-${{ hashFiles('mix.lock') }}-${{ github.ref }}
+          restore-keys: |
+            ${{ env.CACHE_VERSION }}-{{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-format-${{ hashFiles('mix.lock') }}-${{ format('refs/heads/{0}', github.event.repository.default_branch) }}
+            ${{ env.CACHE_VERSION }}-{{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-format-
+            ${{ env.CACHE_VERSION }}-{{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-
+          path: |
+            _build
+            deps
+      - if: steps.cache.outputs.cache-hit != 'true'
+        run: mix deps.get
+      - run: mix format --check-formatted
+
+  Test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+      - id: cache
+        uses: actions/cache@v3
+        with:
+          key: |
+            ${{ env.CACHE_VERSION }}-{{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-test-${{ hashFiles('mix.lock') }}-${{ github.ref }}
+          restore-keys: |
+            ${{ env.CACHE_VERSION }}-{{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-test-${{ hashFiles('mix.lock') }}-${{ format('refs/heads/{0}', github.event.repository.default_branch) }}
+            ${{ env.CACHE_VERSION }}-{{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-test-
+            ${{ env.CACHE_VERSION }}-{{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-
+          path: |
+            _build
+            deps
+      - if: steps.cache.outputs.cache-hit != 'true'
+        run: mix deps.get
+      - run: mix compile --warnings-as-errors
+      - run: mix test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,45 +6,15 @@ on:
   push:
     branches:
       - main
-jobs:
-  Dialyzer:
-    strategy:
-      matrix:
-        elixir: ['1.13']
-        otp: [25]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: set cache key
-        id: cache_key
-        run: |
-          mix_hash="${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}"
-          echo "::set-output name=mix_hash::$mix_hash"
-      - uses: actions/cache@v2
-        with:
-          path: |
-            _build/dev/*.plt
-            _build/dev/*.plt.hash
-          key: plt-cache-${{ steps.cache_key.outputs.mix_hash }}
-          restore-keys: |
-            plt-cache-
-      - uses: erlef/setup-beam@v1
-        with:
-          otp-version: ${{matrix.otp}}
-          elixir-version: ${{matrix.elixir}}
-      - run: mix deps.get
-      - run: mix dialyzer
 
+jobs:
   Deploy:
     if: ${{ github.repository_owner == 'elixirschool' }}
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v3
-
-      - name: Setup Fly
-        uses: superfly/flyctl-actions/setup-flyctl@master
-
-      - name: Deploy
-        run: fly deploy --remote-only
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/lib/mix/tasks/school_house.gen.rss.ex
+++ b/lib/mix/tasks/school_house.gen.rss.ex
@@ -45,9 +45,13 @@ defmodule Mix.Tasks.SchoolHouse.Gen.Rss do
   end
 
   defp write_to_priv_file!(file_path, contents) do
-    :school_house
-    |> Application.app_dir(file_path)
-    |> File.write!(contents)
+    full_file_path = Application.app_dir(:school_house, file_path)
+
+    full_file_path
+    |> Path.dirname()
+    |> File.mkdir_p!()
+
+    File.write!(full_file_path, contents)
   end
 
   defp link_xml(post, uri) do

--- a/lib/mix/tasks/school_house.gen.sitemap.ex
+++ b/lib/mix/tasks/school_house.gen.sitemap.ex
@@ -43,9 +43,13 @@ defmodule Mix.Tasks.SchoolHouse.Gen.Sitemap do
   end
 
   defp write_to_priv_file!(file_path, contents) do
-    :school_house
-    |> Application.app_dir(file_path)
-    |> File.write!(contents)
+    full_file_path = Application.app_dir(:school_house, file_path)
+
+    full_file_path
+    |> Path.dirname()
+    |> File.mkdir_p!()
+
+    File.write!(full_file_path, contents)
   end
 
   defp generate_document(links) do

--- a/mix.exs
+++ b/mix.exs
@@ -64,7 +64,7 @@ defmodule SchoolHouse.MixProject do
       {:telemetry_poller, "~> 0.5"},
 
       # Dev & Test dependencies
-      {:credo, "1.6.4", only: :dev},
+      {:credo, "1.6.4", only: [:dev, :test]},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
       {:floki, ">= 0.0.0", only: :test},
       {:phoenix_live_reload, "~> 1.2", only: :dev}


### PR DESCRIPTION
This
- Moves dialyzer to run in CI instead of deploy
- Adds caching to all steps. I've been using this at Stord for a while and it's been pretty good. There is a `CACHE_VERSION` env value you can increment to force cache busting if you need
- Add a build step to CI that attempts to build the Dockerfile
- Adds concurrency settings to cancel any CI that is already running on a commit