### PR TITLE
patch: make markdown code more contrast

### DIFF
--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -180,7 +180,10 @@ module.exports = {
                         },
                         thead: {
                             color: theme('colors.brand-gray-300')
-                        }
+                        },
+                        'pre code': {
+                            color: colors.white
+                        },
                     }
                 }
             }),


### PR DESCRIPTION
In dark theme some code in snippets is unreadable. It's usualy relate to some bash scripts.

Example of unreadable snippet:
<img width="368" alt="image" src="https://user-images.githubusercontent.com/3465012/190508712-82269b71-1d10-44e6-a003-9d4ceec24c44.png">

I guess, with white color of text this snippets read much more comfortable.
<img width="433" alt="image" src="https://user-images.githubusercontent.com/3465012/190508586-99f66d04-9ed0-4f74-a58d-a783a0d066a2.png">

So as i can check, it shouldn't affect any other usage of 'code' snippets.
