### PR TITLE
🐛 Fix "Coming Soon" badge translation in Lesson popover

### DIFF
--- a/lib/school_house_web/templates/report/_coming_soon.html.heex
+++ b/lib/school_house_web/templates/report/_coming_soon.html.heex
@@ -3,6 +3,6 @@
     <%= @line.name %>
   </td>
   <td colspan="3" class="px-6 py-4 text-sm text-center text-primary dark:text-primary-dark whitespace-nowrap">
-    <%= gettext("Coming Soon!") %>
+    <%= gettext("Coming Soon") %>!
   </td>
 </tr>

--- a/lib/school_house_web/views/html_helpers.ex
+++ b/lib/school_house_web/views/html_helpers.ex
@@ -4,6 +4,7 @@ defmodule SchoolHouseWeb.HtmlHelpers do
   """
   use Phoenix.HTML
 
+  import SchoolHouseWeb.Gettext
   alias SchoolHouseWeb.Router.Helpers, as: Routes
   alias SchoolHouse.Lessons
 
@@ -64,7 +65,7 @@ defmodule SchoolHouseWeb.HtmlHelpers do
   def maybe_coming_soon_badge(true) do
     content_tag(
       :span,
-      Gettext.gettext(SchoolHouseWeb.Gettext, "Coming Soon"),
+      gettext("Coming Soon"),
       class: "rounded py-px px-1 bg-purple text-xs text-white font-semibold self-center flex-shrink-0"
     )
   end

--- a/priv/gettext/ar/LC_MESSAGES/default.po
+++ b/priv/gettext/ar/LC_MESSAGES/default.po
@@ -372,7 +372,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/school_house_web/templates/report/_coming_soon.html.heex:6
-msgid "Coming Soon!"
+msgid "Coming Soon"
 msgstr ""
 
 #, elixir-format

--- a/priv/gettext/bg/LC_MESSAGES/default.po
+++ b/priv/gettext/bg/LC_MESSAGES/default.po
@@ -372,7 +372,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/school_house_web/templates/report/_coming_soon.html.heex:6
-msgid "Coming Soon!"
+msgid "Coming Soon"
 msgstr ""
 
 #, elixir-format

--- a/priv/gettext/bn/LC_MESSAGES/default.po
+++ b/priv/gettext/bn/LC_MESSAGES/default.po
@@ -372,7 +372,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/school_house_web/templates/report/_coming_soon.html.heex:6
-msgid "Coming Soon!"
+msgid "Coming Soon"
 msgstr ""
 
 #, elixir-format

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -372,7 +372,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/school_house_web/templates/report/_coming_soon.html.heex:6
-msgid "Coming Soon!"
+msgid "Coming Soon"
 msgstr ""
 
 #, elixir-format

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -371,7 +371,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/school_house_web/templates/report/_coming_soon.html.heex:6
-msgid "Coming Soon!"
+msgid "Coming Soon"
 msgstr ""
 
 #, elixir-format

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -371,6 +371,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/school_house_web/templates/report/_coming_soon.html.heex:6
+#: lib/school_house_web/views/html_helpers.ex:68
 msgid "Coming Soon"
 msgstr ""
 
@@ -411,7 +412,7 @@ msgid "Date"
 msgstr ""
 
 #, elixir-format
-#: lib/school_house_web/templates/layout/_lesson_menu.html.heex:312
+#: lib/school_house_web/templates/layout/_lesson_menu.html.heex:317
 msgid "Debugging"
 msgstr ""
 

--- a/priv/gettext/el/LC_MESSAGES/default.po
+++ b/priv/gettext/el/LC_MESSAGES/default.po
@@ -372,7 +372,7 @@ msgstr "Δείτε όλα τα υπέροχα Podcast που εστιάζουν 
 
 #, elixir-format
 #: lib/school_house_web/templates/report/_coming_soon.html.heex:6
-msgid "Coming Soon!"
+msgid "Coming Soon"
 msgstr "Έρχεται σύντομα!"
 
 #, elixir-format

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -372,7 +372,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/school_house_web/templates/report/_coming_soon.html.heex:6
-msgid "Coming Soon!"
+msgid "Coming Soon"
 msgstr ""
 
 #, elixir-format

--- a/priv/gettext/es/LC_MESSAGES/default.po
+++ b/priv/gettext/es/LC_MESSAGES/default.po
@@ -372,7 +372,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/school_house_web/templates/report/_coming_soon.html.heex:6
-msgid "Coming Soon!"
+msgid "Coming Soon"
 msgstr ""
 
 #, elixir-format

--- a/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/priv/gettext/fr/LC_MESSAGES/default.po
@@ -372,7 +372,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/school_house_web/templates/report/_coming_soon.html.heex:6
-msgid "Coming Soon!"
+msgid "Coming Soon"
 msgstr ""
 
 #, elixir-format

--- a/priv/gettext/id/LC_MESSAGES/default.po
+++ b/priv/gettext/id/LC_MESSAGES/default.po
@@ -372,7 +372,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/school_house_web/templates/report/_coming_soon.html.heex:6
-msgid "Coming Soon!"
+msgid "Coming Soon"
 msgstr ""
 
 #, elixir-format

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -372,7 +372,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/school_house_web/templates/report/_coming_soon.html.heex:6
-msgid "Coming Soon!"
+msgid "Coming Soon"
 msgstr ""
 
 #, elixir-format

--- a/priv/gettext/ja/LC_MESSAGES/default.po
+++ b/priv/gettext/ja/LC_MESSAGES/default.po
@@ -374,7 +374,7 @@ msgstr "ElixirとBEAM仮想マシンに焦点が当てられている全ての�
 
 #, elixir-format
 #: lib/school_house_web/templates/report/_coming_soon.html.heex:6
-msgid "Coming Soon!"
+msgid "Coming Soon"
 msgstr "近日公開！"
 
 #, elixir-format

--- a/priv/gettext/ko/LC_MESSAGES/default.po
+++ b/priv/gettext/ko/LC_MESSAGES/default.po
@@ -372,7 +372,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/school_house_web/templates/report/_coming_soon.html.heex:6
-msgid "Coming Soon!"
+msgid "Coming Soon"
 msgstr ""
 
 #, elixir-format

--- a/priv/gettext/ms/LC_MESSAGES/default.po
+++ b/priv/gettext/ms/LC_MESSAGES/default.po
@@ -372,7 +372,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/school_house_web/templates/report/_coming_soon.html.heex:6
-msgid "Coming Soon!"
+msgid "Coming Soon"
 msgstr ""
 
 #, elixir-format

--- a/priv/gettext/no/LC_MESSAGES/default.po
+++ b/priv/gettext/no/LC_MESSAGES/default.po
@@ -372,7 +372,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/school_house_web/templates/report/_coming_soon.html.heex:6
-msgid "Coming Soon!"
+msgid "Coming Soon"
 msgstr ""
 
 #, elixir-format

--- a/priv/gettext/pl/LC_MESSAGES/default.po
+++ b/priv/gettext/pl/LC_MESSAGES/default.po
@@ -372,7 +372,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/school_house_web/templates/report/_coming_soon.html.heex:6
-msgid "Coming Soon!"
+msgid "Coming Soon"
 msgstr ""
 
 #, elixir-format

--- a/priv/gettext/pt/LC_MESSAGES/default.po
+++ b/priv/gettext/pt/LC_MESSAGES/default.po
@@ -372,7 +372,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/school_house_web/templates/report/_coming_soon.html.heex:6
-msgid "Coming Soon!"
+msgid "Coming Soon"
 msgstr ""
 
 #, elixir-format

--- a/priv/gettext/ru/LC_MESSAGES/default.po
+++ b/priv/gettext/ru/LC_MESSAGES/default.po
@@ -372,7 +372,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/school_house_web/templates/report/_coming_soon.html.heex:6
-msgid "Coming Soon!"
+msgid "Coming Soon"
 msgstr ""
 
 #, elixir-format

--- a/priv/gettext/sk/LC_MESSAGES/default.po
+++ b/priv/gettext/sk/LC_MESSAGES/default.po
@@ -372,7 +372,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/school_house_web/templates/report/_coming_soon.html.heex:6
-msgid "Coming Soon!"
+msgid "Coming Soon"
 msgstr ""
 
 #, elixir-format

--- a/priv/gettext/ta/LC_MESSAGES/default.po
+++ b/priv/gettext/ta/LC_MESSAGES/default.po
@@ -372,7 +372,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/school_house_web/templates/report/_coming_soon.html.heex:6
-msgid "Coming Soon!"
+msgid "Coming Soon"
 msgstr ""
 
 #, elixir-format

--- a/priv/gettext/th/LC_MESSAGES/default.po
+++ b/priv/gettext/th/LC_MESSAGES/default.po
@@ -372,7 +372,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/school_house_web/templates/report/_coming_soon.html.heex:6
-msgid "Coming Soon!"
+msgid "Coming Soon"
 msgstr ""
 
 #, elixir-format

--- a/priv/gettext/tr/LC_MESSAGES/default.po
+++ b/priv/gettext/tr/LC_MESSAGES/default.po
@@ -372,7 +372,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/school_house_web/templates/report/_coming_soon.html.heex:6
-msgid "Coming Soon!"
+msgid "Coming Soon"
 msgstr ""
 
 #, elixir-format

--- a/priv/gettext/uk/LC_MESSAGES/default.po
+++ b/priv/gettext/uk/LC_MESSAGES/default.po
@@ -372,7 +372,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/school_house_web/templates/report/_coming_soon.html.heex:6
-msgid "Coming Soon!"
+msgid "Coming Soon"
 msgstr ""
 
 #, elixir-format

--- a/priv/gettext/vi/LC_MESSAGES/default.po
+++ b/priv/gettext/vi/LC_MESSAGES/default.po
@@ -372,7 +372,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/school_house_web/templates/report/_coming_soon.html.heex:6
-msgid "Coming Soon!"
+msgid "Coming Soon"
 msgstr ""
 
 #, elixir-format


### PR DESCRIPTION
Noticed during the translation of the Norwegian translation file that the badge "Coming Soon" wasn't being translated. 

This text is resolved in the file changed for this PR, and was the only place that didn't call `gettext` directly. This file doesn't `use` the `:view` of `SchoolHouseWeb`, so the `Gettext` module needs to be imported manually for this to work.

Verified that it works based on the Norwegian translation that I have open in https://github.com/elixirschool/school_house/pull/201