### PR TITLE
Default to Device Preference for Site Theme

### DIFF
--- a/assets/js/dark-mode.js
+++ b/assets/js/dark-mode.js
@@ -1,5 +1,7 @@
-const darkModeToggleContainer = document.getElementById("dark-mode-toggle-container")
-const darkModeToggleInput = document.getElementById("dark-mode-toggle")
+const darkModeToggleContainer = document.getElementById(
+    'dark-mode-toggle-container'
+)
+const darkModeToggleInput = document.getElementById('dark-mode-toggle')
 
 // set up dark mode toggle
 function setDarkMode(on) {

--- a/assets/js/dark-mode.js
+++ b/assets/js/dark-mode.js
@@ -8,19 +8,29 @@ function setDarkMode(on) {
     if (on) {
         darkModeToggleInput.checked = true
         document.documentElement.classList.add('dark')
-        localStorage.theme = 'dark'
         document.getElementById('sun-icon').classList.add('hidden')
         document.getElementById('moon-icon').classList.remove('hidden')
     } else {
         darkModeToggleInput.checked = false
         document.documentElement.classList.remove('dark')
-        localStorage.theme = 'light'
         document.getElementById('moon-icon').classList.add('hidden')
         document.getElementById('sun-icon').classList.remove('hidden')
     }
 }
 
-if (document.documentElement.classList.contains('dark')) {
+// Will prefer dark mode, if the user has set it on their device.
+const userPrefersDarkMode =
+    window.matchMedia &&
+    window.matchMedia('(prefers-color-scheme: dark)').matches
+
+// If the user has taken an active choice to set mode, which is stored
+// in local storage, use that. Otherwise, prefer user device preference.
+if (localStorage.theme) {
+    setDarkMode(localStorage.theme === 'dark')
+} else if (
+    userPrefersDarkMode ||
+    document.documentElement.classList.contains('dark')
+) {
     setDarkMode(true)
 } else {
     setDarkMode(false)
@@ -28,8 +38,10 @@ if (document.documentElement.classList.contains('dark')) {
 
 darkModeToggleContainer.addEventListener('click', function () {
     if (darkModeToggleInput.checked) {
+        localStorage.theme = 'light'
         setDarkMode(false)
     } else {
+        localStorage.theme = 'dark'
         setDarkMode(true)
     }
 })

--- a/lib/school_house_web/templates/page/index.html.heex
+++ b/lib/school_house_web/templates/page/index.html.heex
@@ -10,27 +10,26 @@
       </p>
       <p class="mb-6 leading-relaxed prose dark:prose-dark">
         <%= gettext("Through the hard work of volunteers Elixir School has been translated to many languages. Some of these translations include: ")%>
-        <a href="/bn" title="Bengali"><%= gettext("Bengali") %></a>,
-        <a href="/zh-hans" title="Chinese, in simplified script"><%= gettext("Chinese (simplified)") %></a>, 
-        <a href="/zh-hant" title="Chinese, in traditional script"><%= gettext("Chinese (traditional)") %></a>, 
-        <a href="/de" title="German"><%= gettext("German") %></a>,
-        <a href="/el" title="Modern Greek"><%= gettext("Greek (Modern)") %></a>,
-        <a href="/id" title="Indonesian"><%= gettext("Indonesian") %></a>,
-        <a href="/it" title="Italian"><%= gettext("Italian") %></a>,
-        <a href="/ja" title="Japanese"><%= gettext("Japanese") %></a>,
-        <a href="/ko" title="Korean"><%= gettext("Korean") %></a>,
-        <a href="/ms" title="Malay"><%= gettext("Malay") %></a>,
-        <a href="/no" title="Norwegian"><%= gettext("Norwegian") %></a>,
-        <a href="/pl" title="Polish"><%= gettext("Polski")%></a>,
-        <a href="/pt" title="Portuguese"><%= gettext("Portuguese") %></a>,
-        <a href="/ru" title="Russian"><%= gettext("Russian") %></a>,
-        <a href="/sk" title="Slovak"><%= gettext("Slovak") %></a>, 
-        <a href="/es" title="Spanish"><%= gettext("Spanish") %></a>, 
-        <a href="/th" title="Thai"><%= gettext("Thai") %></a>,
-        <a href="/tr" title="Turkish"><%= gettext("Turkish") %></a>,
-        <a href="/uk" title="Ukrainian"><%= gettext("Ukrainian") %></a>,
-				<%= gettext("and")%>
-        <a href="/vi" title="Vietnamese"><%= gettext("Vietnamese") %></a>.
+        <a href="/bn" title="Bengali">বাংলা</a>,
+        <a href="/de" title="German">Deutsch</a>,
+        <a href="/el" title="Modern Greek">Ελληνικά</a>.
+        <a href="/es" title="Spanish">Español</a>, 
+        <a href="/id" title="Indonesian">Bahasa Indonesia</a>,
+        <a href="/it" title="Italian">Italiano</a>,
+        <a href="/ja" title="Japanese">日本語</a>,
+        <a href="/ko" title="Korean">한국어</a>,
+        <a href="/ms" title="Malay">Bahasa Melayu</a>,
+        <a href="/no" title="Norwegian">Norsk</a>,
+        <a href="/pl" title="Polish">Polski</a>,
+        <a href="/pt" title="Portuguese">Português</a>,
+        <a href="/vi" title="Vietnamese">Việt ngữ</a>,
+        <a href="/zh-hans" title="Chinese, in simplified script">简体中文</a>, 
+        <a href="/zh-hant" title="Chinese, in traditional script">繁體中文</a>, 
+        <a href="/ru" title="Russian">Русский</a>,
+        <a href="/sk" title="Slovak">Slovenčina</a>, 
+        <a href="/tr" title="Turkish">Türkçe</a>,
+        <a href="/th" title="Thai">ภาษาไทย</a>, <%= gettext("and")%>
+        <a href="/uk" title="Ukrainian">Українською</a>,
       </p>
       <p class="mb-6 leading-relaxed">
         <%= gettext("We welcome and encourage you to join us in continuing to make Elixir School great by getting involved at elixirschool/elixirschool!")%>

--- a/lib/school_house_web/templates/page/index.html.heex
+++ b/lib/school_house_web/templates/page/index.html.heex
@@ -22,12 +22,12 @@
         <a href="/no" title="Norwegian">Norsk</a>,
         <a href="/pl" title="Polish">Polski</a>,
         <a href="/pt" title="Portuguese">Português</a>,
-        <a href="/vi" title="Vietnamese">Việt ngữ</a>,
         <a href="/ru" title="Russian">Русский</a>,
         <a href="/sk" title="Slovak">Slovenčina</a>, 
         <a href="/tr" title="Turkish">Türkçe</a>,
         <a href="/th" title="Thai">ภาษาไทย</a>,
         <a href="/uk" title="Ukrainian">Українською</a>,
+        <a href="/vi" title="Vietnamese">Việt ngữ</a>,
         <a href="/zh-hans" title="Chinese, in simplified script">简体中文</a> <%= gettext("and")%>
         <a href="/zh-hant" title="Chinese, in traditional script">繁體中文</a>.
       </p>

--- a/lib/school_house_web/templates/page/index.html.heex
+++ b/lib/school_house_web/templates/page/index.html.heex
@@ -10,25 +10,27 @@
       </p>
       <p class="mb-6 leading-relaxed prose dark:prose-dark">
         <%= gettext("Through the hard work of volunteers Elixir School has been translated to many languages. Some of these translations include: ")%>
-        <a href="/vi" title="Vietnamese">Việt ngữ</a>,
-        <a href="/zh-hans" title="Chinese, in simplified script">简体中文</a>, 
-        <a href="/zh-hant" title="Chinese, in traditional script">繁體中文</a>, 
-        <a href="/es" title="Spanish">Español</a>, 
-        <a href="/sk" title="Slovak">Slovenčina</a>, 
-        <a href="/ja" title="Japanese">日本語</a>,
-        <a href="/pl" title="Polish">Polski</a>,
-        <a href="/pt" title="Portuguese">Português</a>,
-        <a href="/ru" title="Russian">Русский</a>,
-        <a href="/id" title="Indonesian">Bahasa Indonesia</a>,
-        <a href="/ms" title="Malay">Bahasa Melayu</a>,
-        <a href="/uk" title="Ukrainian">Українською</a>,
-        <a href="/ko" title="Korean">한국어</a>,
-        <a href="/it" title="Italian">Italiano</a>,
-        <a href="/de" title="German">Deutsch</a>,
-        <a href="/bn" title="Bengali">বাংলা</a>,
-        <a href="/tr" title="Turkish">Türkçe</a>,
-        <a href="/th" title="Thai">ภาษาไทย</a>, <%= gettext("and")%>
-        <a href="/el" title="Modern Greek">Ελληνικά</a>.
+        <a href="/bn" title="Bengali"><%= gettext("Bengali") %></a>,
+        <a href="/zh-hans" title="Chinese, in simplified script"><%= gettext("Chinese (simplified)") %></a>, 
+        <a href="/zh-hant" title="Chinese, in traditional script"><%= gettext("Chinese (traditional)") %></a>, 
+        <a href="/de" title="German"><%= gettext("German") %></a>,
+        <a href="/el" title="Modern Greek"><%= gettext("Greek (Modern)") %></a>,
+        <a href="/id" title="Indonesian"><%= gettext("Indonesian") %></a>,
+        <a href="/it" title="Italian"><%= gettext("Italian") %></a>,
+        <a href="/ja" title="Japanese"><%= gettext("Japanese") %></a>,
+        <a href="/ko" title="Korean"><%= gettext("Korean") %></a>,
+        <a href="/ms" title="Malay"><%= gettext("Malay") %></a>,
+        <a href="/no" title="Norwegian"><%= gettext("Norwegian") %></a>,
+        <a href="/pl" title="Polish"><%= gettext("Polski")%></a>,
+        <a href="/pt" title="Portuguese"><%= gettext("Portuguese") %></a>,
+        <a href="/ru" title="Russian"><%= gettext("Russian") %></a>,
+        <a href="/sk" title="Slovak"><%= gettext("Slovak") %></a>, 
+        <a href="/es" title="Spanish"><%= gettext("Spanish") %></a>, 
+        <a href="/th" title="Thai"><%= gettext("Thai") %></a>,
+        <a href="/tr" title="Turkish"><%= gettext("Turkish") %></a>,
+        <a href="/uk" title="Ukrainian"><%= gettext("Ukrainian") %></a>,
+				<%= gettext("and")%>
+        <a href="/vi" title="Vietnamese"><%= gettext("Vietnamese") %></a>.
       </p>
       <p class="mb-6 leading-relaxed">
         <%= gettext("We welcome and encourage you to join us in continuing to make Elixir School great by getting involved at elixirschool/elixirschool!")%>

--- a/lib/school_house_web/templates/page/index.html.heex
+++ b/lib/school_house_web/templates/page/index.html.heex
@@ -12,7 +12,7 @@
         <%= gettext("Through the hard work of volunteers Elixir School has been translated to many languages. Some of these translations include: ")%>
         <a href="/bn" title="Bengali">বাংলা</a>,
         <a href="/de" title="German">Deutsch</a>,
-        <a href="/el" title="Modern Greek">Ελληνικά</a>.
+        <a href="/el" title="Modern Greek">Ελληνικά</a>,
         <a href="/es" title="Spanish">Español</a>, 
         <a href="/id" title="Indonesian">Bahasa Indonesia</a>,
         <a href="/it" title="Italian">Italiano</a>,
@@ -23,13 +23,13 @@
         <a href="/pl" title="Polish">Polski</a>,
         <a href="/pt" title="Portuguese">Português</a>,
         <a href="/vi" title="Vietnamese">Việt ngữ</a>,
-        <a href="/zh-hans" title="Chinese, in simplified script">简体中文</a>, 
-        <a href="/zh-hant" title="Chinese, in traditional script">繁體中文</a>, 
         <a href="/ru" title="Russian">Русский</a>,
         <a href="/sk" title="Slovak">Slovenčina</a>, 
         <a href="/tr" title="Turkish">Türkçe</a>,
-        <a href="/th" title="Thai">ภาษาไทย</a>, <%= gettext("and")%>
+        <a href="/th" title="Thai">ภาษาไทย</a>,
         <a href="/uk" title="Ukrainian">Українською</a>,
+        <a href="/zh-hans" title="Chinese, in simplified script">简体中文</a> <%= gettext("and")%>
+        <a href="/zh-hant" title="Chinese, in traditional script">繁體中文</a>.
       </p>
       <p class="mb-6 leading-relaxed">
         <%= gettext("We welcome and encourage you to join us in continuing to make Elixir School great by getting involved at elixirschool/elixirschool!")%>

--- a/priv/gettext/no/LC_MESSAGES/default.po
+++ b/priv/gettext/no/LC_MESSAGES/default.po
@@ -174,7 +174,7 @@ msgstr "OTP Concurrency"
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:142
 msgid "OTP Distribution"
-msgstr "OTP Distrubisjon"
+msgstr "OTP Distribusjon"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:137

--- a/priv/gettext/no/LC_MESSAGES/default.po
+++ b/priv/gettext/no/LC_MESSAGES/default.po
@@ -17,217 +17,218 @@ msgstr ""
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:182 lib/school_house_web/templates/layout/_lesson_menu.html.heex:240
 #: lib/school_house_web/templates/lesson/_basics.html.heex:5 lib/school_house_web/templates/report/report.html.heex:11
 msgid "Basics"
-msgstr ""
+msgstr "Grunnleggende"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:19
 msgid "Collections"
-msgstr ""
+msgstr "Samlinger"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:34
 msgid "Control Structures"
-msgstr ""
+msgstr "Kontrollstrukturer"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:24
 msgid "Enum"
-msgstr ""
+msgstr "Enum"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:39
 msgid "Functions"
-msgstr ""
+msgstr "Funksjoner"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:49
 msgid "Modules"
-msgstr ""
+msgstr "Moduler"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:29
 msgid "Pattern Matching"
-msgstr ""
+msgstr "Pattern Matching"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:44
 msgid "Pipe Operator"
-msgstr ""
+msgstr "Pipe Operator"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_footer.html.heex:65
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:128 lib/school_house_web/templates/lesson/_advanced.html.heex:5
 #: lib/school_house_web/templates/report/report.html.heex:13
 msgid "Advanced"
-msgstr ""
+msgstr "Avansert"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:250
 msgid "Associations"
-msgstr ""
+msgstr "Assosiasjoner"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:162
 msgid "Behaviours"
-msgstr ""
+msgstr "Oppførsel"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:245
 msgid "Changesets"
-msgstr ""
+msgstr "Changesets"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:69
 msgid "Comprehensions"
-msgstr ""
+msgstr "Komprehensjoner"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:120
 #: lib/school_house_web/templates/page/why.html.heex:157
 msgid "Concurrency"
-msgstr ""
+msgstr "Concurrency"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:100
 msgid "Custom Mix Tasks"
-msgstr ""
+msgstr "Egendefinerte Mix Tasks"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_footer.html.heex:73
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:211 lib/school_house_web/templates/lesson/_data_processing.html.heex:5
 #: lib/school_house_web/templates/report/report.html.heex:15
 msgid "Data Processing"
-msgstr ""
+msgstr "Dataprosessering"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:79
 msgid "Date and Time"
-msgstr ""
+msgstr "Dato og tid"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:187
 msgid "Doctests"
-msgstr ""
+msgstr "Doctests"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:64
 msgid "Documentation"
-msgstr ""
+msgstr "Dokumentasjon"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_footer.html.heex:77
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:236 lib/school_house_web/templates/lesson/_ecto.html.heex:5
 #: lib/school_house_web/templates/report/report.html.heex:16
 msgid "Ecto"
-msgstr ""
+msgstr "Ecto"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:105
 msgid "Erlang Interoperability"
-msgstr ""
+msgstr "Erlang Interoperabilitet"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:110
 msgid "Error Handling"
-msgstr ""
+msgstr "Feilhåndtering"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:115
 msgid "Executables"
-msgstr ""
+msgstr "Kjørbare filer"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:84
 msgid "IEX Helpers"
-msgstr ""
+msgstr "IEX Hjelpere"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_footer.html.heex:61
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:96 lib/school_house_web/templates/lesson/_intermediate.html.heex:5
 #: lib/school_house_web/templates/report/report.html.heex:12
 msgid "Intermediate"
-msgstr ""
+msgstr "Middels"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:147
 msgid "Metaprogramming"
-msgstr ""
+msgstr "Metaprogrammering"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_footer.html.heex:85
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:298 lib/school_house_web/templates/lesson/_misc.html.heex:5
 #: lib/school_house_web/templates/report/report.html.heex:18
 msgid "Miscellaneous"
-msgstr ""
+msgstr "Diverse"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:54
 msgid "Mix"
-msgstr ""
+msgstr "Mix"
+
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:132
 msgid "OTP Concurrency"
-msgstr ""
+msgstr "OTP Concurrency"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:142
 msgid "OTP Distribution"
-msgstr ""
+msgstr "OTP Distrubisjon"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:137
 msgid "OTP Supervisors"
-msgstr ""
+msgstr "OTP Overvåkere"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:167
 msgid "Protocols"
-msgstr ""
+msgstr "Protokoller"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:260
 msgid "Querying: Advanced"
-msgstr ""
+msgstr "Spørringer: Avansert"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:255
 msgid "Querying: Basics"
-msgstr ""
+msgstr "Spørringer: Grunnleggende"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:59
 msgid "Sigils"
-msgstr ""
+msgstr "Sigils"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:157
 msgid "Specifications and types"
-msgstr ""
+msgstr "Spesifikasjoner og typer"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_footer.html.heex:81
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:268 lib/school_house_web/templates/lesson/_storage.html.heex:5
 #: lib/school_house_web/templates/report/report.html.heex:17
 msgid "Storage"
-msgstr ""
+msgstr "Lagring"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:74
 msgid "Strings"
-msgstr ""
+msgstr "Strenger"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_footer.html.heex:69
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:178 lib/school_house_web/templates/lesson/_testing.html.heex:5
 #: lib/school_house_web/templates/report/report.html.heex:14
 msgid "Testing"
-msgstr ""
+msgstr "Testing"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:152
 msgid "Umbrella Projects"
-msgstr ""
+msgstr "Umbrella Prosjekter"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:192
@@ -239,363 +240,363 @@ msgstr ""
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:327 lib/school_house_web/templates/layout/_lesson_menu.html.heex:332
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:337 lib/school_house_web/templates/layout/_lesson_menu.html.heex:342
 msgid "library"
-msgstr ""
+msgstr "bibliotek"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:109
 msgid "Scalable"
-msgstr ""
+msgstr "Skalerbar"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_footer.html.heex:41
 #: lib/school_house_web/templates/layout/_header.html.heex:13 lib/school_house_web/templates/page/index.html.heex:57
 #: lib/school_house_web/templates/page/why.html.heex:5
 msgid "Why Elixir?"
-msgstr ""
+msgstr "Hvorfor Elixir?"
 
 #, elixir-format
 #: lib/school_house_web/templates/report/_section.html.heex:16
 msgid "Lesson"
-msgstr ""
+msgstr "Leksjon"
 
 #, elixir-format
 #: lib/school_house_web/templates/report/_section.html.heex:22
 msgid "Original Version"
-msgstr ""
+msgstr "Opprinnelig versjon"
 
 #, elixir-format
 #: lib/school_house_web/templates/report/_section.html.heex:19
 msgid "Translated Title"
-msgstr ""
+msgstr "Oversatt tittel"
 
 #, elixir-format
 #: lib/school_house_web/templates/report/_section.html.heex:25
 msgid "Translated Version"
-msgstr ""
+msgstr "Oversatt versjon"
 
 #, elixir-format
 #: lib/school_house_web/controllers/page_controller.ex:19
 #: lib/school_house_web/templates/layout/_footer.html.heex:120 lib/school_house_web/templates/report/report.html.heex:5
 msgid "Translation Report"
-msgstr ""
+msgstr "Oversettelsesrapport"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:224
 msgid "A Slack alternative built with Elixir is fast becoming a popular chat option for the community."
-msgstr ""
+msgstr "Et alternativ til Slack bygget med Elixir. Er nå en av verdens største platformer for chatting og nettsamfunn."
 
 #, elixir-format
 #: lib/school_house_web/views/error_view.ex:21
 msgid "An error occurred."
-msgstr ""
+msgstr "En feil har oppstått"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_footer.html.heex:97
 msgid "Announcements"
-msgstr ""
+msgstr "Kunngjøringer"
 
 #, elixir-format
 #: lib/school_house_web/templates/post/index.html.heex:8
 msgid "Articles authored by Elixir School contributors and members of the community."
-msgstr ""
+msgstr "Artikler skrevet av Elixir School bidragsytere og medlemmer av samfunnet."
 
 #, elixir-format
 #: lib/school_house_web/templates/page/get_involved.html.heex:41
 msgid "As you read lessons, if you see an opportunity for improvement go ahead and create a pull request with the change, the next reader will thank you. Steps for translating a lesson"
-msgstr ""
+msgstr "Hvis du ser en mulighet for forbedring, mens du leser leksjonene, opprett gjerne en pull request med dine forslag Neste leser vil takke deg. Steg for å oversette en leksjon"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:225
 msgid "Be sure to check it out!"
-msgstr ""
+msgstr "Sjekk det ut!"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:270
 msgid "Be sure to follow the popular Elixir hashtags"
-msgstr ""
+msgstr "Følg de populære Elixir hashtaggene"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_footer.html.heex:93
 #: lib/school_house_web/templates/layout/_header.html.heex:19
 msgid "Blog"
-msgstr ""
+msgstr "Blogg"
 
 #, elixir-format
 #: lib/school_house_web/templates/lesson/_intermediate.html.heex:8
 msgid "Building on upon our foundation these lessons introduce topics like concurrency, error handling, and interoperability."
-msgstr ""
+msgstr "Bygger på fundamentet fra de grunnleggende leksjonene. Disse leksjonene introduserer emner om concurrency, feilhåndtering og interoperabilitet."
 
 #, elixir-format
 #: lib/school_house_web/templates/page/index.html.heex:92
 msgid "Built on the back of a giant, the Erlang runtime system, Elixir takes things even further with easy extensibility, compatibility with Erlang and other BEAM languages, and an ever expanding collection of libraries and packages to improve developer happiness."
-msgstr ""
+msgstr "Bygget på skuldrene til en kjempe, Erlang, tar Elixir ting enda lenger med enkel utvidbarhet, kompatibilitet med Erlang og andre BEAM språk, og en stadig voksende samling av biblioteker og pakker for å forbedre utvikleropplevelsen."
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:64
 msgid "Bundled with Elixir is the venerable ExUnit library providing everything necessary to comprehensively test your applications."
-msgstr ""
+msgstr "Pakket sammen med Elixir, får man den anerkjente pakken ExUnit som gir deg alt du trenger for å skrive gjennomført gode tester for din applikasjon."
 
 #, elixir-format
 #: lib/school_house_web/templates/post/post.html.heex:22
 msgid "By"
-msgstr ""
+msgstr "City"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/index.html.heex:143
 msgid "By The Numbers"
-msgstr ""
+msgstr "Tall og fakta"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:29
 msgid "By eliminating the ability to mutate state outside of scope, functional programs are often easier to follow and contain fewer bugs."
-msgstr ""
+msgstr "Ved å eliminere muligheten til å endre tilstand utenfor scope, er funksjonelle programmer ofte lettere å lese og inneholder som regel færre feil."
 
 #, elixir-format
 #: lib/school_house_web/templates/page/index.html.heex:73
 msgid "By focusing on breaking problems down into simple side-effect free functions we can ensure fewer bugs, better test coverage, while incrementally building our solutions through the composition of well tested functions."
-msgstr ""
+msgstr "Ved å fokusere på å dele opp problemer i enkle enkeltstående funksjoner uten bivirkninger, kan vi være sikre på færre feil, bedre testdekning, mens vi gradvis bygger løsninger gjennom oppbygning av godt testede funksjoner."
 
 #, elixir-format
 #: lib/school_house_web/templates/lesson/lesson.html.heex:19
 msgid "Caught a mistake or want to contribute to the lesson?"
-msgstr ""
+msgstr "Har du oppdaget en feil eller ønsker å bidra til leksjonen?"
 
 #, elixir-format
 #: lib/school_house_web/live/conferences_live.html.heex:8
 msgid "Check out all of the conferences that focus on Elixir!"
-msgstr ""
+msgstr "Sjekk ut alle konferansene som fokuserer på Elixir!"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/podcasts.html.heex:8
 msgid "Check out all the great of Podcasts that focus on Elixir and the BEAM ecosystem!"
-msgstr ""
+msgstr "Sjekk ut alle de flotte podcastene som fokuserer på Elixir og BEAM-ekosystemet!"
 
 #, elixir-format
 #: lib/school_house_web/templates/report/_coming_soon.html.heex:6
 msgid "Coming Soon!"
-msgstr ""
+msgstr "Kommer snart!"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/index.html.heex:184
 msgid "Companies"
-msgstr ""
+msgstr "Selskaper"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:145
 msgid "Compatible with Erlang"
-msgstr ""
+msgstr "Kompatibel med Erlang"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_footer.html.heex:47
 #: lib/school_house_web/templates/page/index.html.heex:151 lib/school_house_web/templates/page/why.html.heex:282
 msgid "Conferences"
-msgstr ""
+msgstr "Konferanser"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/get_involved.html.heex:53
 msgid "Contribute to the Blog"
-msgstr ""
+msgstr "Bidra til bloggen"
 
 #, elixir-format
 #: lib/school_house_web/live/conferences_live.html.heex:23
 msgid "Country"
-msgstr ""
+msgstr "Land"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:28
 msgid "Data is not mutated, rather transformed, into a new set of data."
-msgstr ""
+msgstr "Data er ikke mutert, men heller transformert til et nytt sett med data."
 
 #, elixir-format
 #: lib/school_house_web/live/conferences_live.html.heex:38
 msgid "Date"
-msgstr ""
+msgstr "Dato"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:312
 msgid "Debugging"
-msgstr ""
+msgstr "Feilsøking"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:221
 msgid "Discord"
-msgstr ""
+msgstr "Discord"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/index.html.heex:60
 msgid "Discover why Elixir's popularity has skyrocketed and new companies adopt it daily."
-msgstr ""
+msgstr "Oppdag hvorfor Elixirs popularitet har skutt fart og hvorfor nye selskaper adopterer det daglig."
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:60
 msgid "Easy to Test"
-msgstr ""
+msgstr "Lett å teste"
 
 #, elixir-format
 #: lib/school_house_web/templates/lesson/lesson.html.heex:21
 msgid "Edit this lesson on GitHub!"
-msgstr ""
+msgstr "Rediger denne leksjonen på GitHub!"
 
 #, elixir-format
 #: lib/school_house_web/live/conferences_live.html.heex:5
 msgid "Elixir Conferences"
-msgstr ""
+msgstr "Elixir-konferanser"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:240
 msgid "Elixir Forum"
-msgstr ""
+msgstr "Elixir Forum"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/podcasts.html.heex:5
 msgid "Elixir Podcasts"
-msgstr ""
+msgstr "Elixir Podcaster"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_footer.html.heex:10
 #: lib/school_house_web/templates/layout/_header.html.heex:8 lib/school_house_web/templates/post/post.html.heex:3
 msgid "Elixir School"
-msgstr ""
+msgstr "Elixir School"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/get_involved.html.heex:24
 msgid "Elixir School is an open source project, with code hosted on"
-msgstr ""
+msgstr "Elixir School er et open source-prosjekt, med kode som er lagret på"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/get_involved.html.heex:8
 msgid "Elixir School is built by contributors, skilled and new alike! Help us make it better and extend the reach of Elixir to anyone that wants to learn. Below are a few ways to contribute."
-msgstr ""
+msgstr "Elixir School er bygget av bidragsytere, både erfarne og nye! Hjelp oss med å gjøre det bedre og utvide Elixirs rekkevidde til alle som ønsker å lære. Under er noen måter å bidra på."
 
 #, elixir-format
 #: lib/school_house_web/templates/page/index.html.heex:8
 msgid "Elixir School is the premier destination for people looking to learn and master the Elixir programming language."
-msgstr ""
+msgstr "Elixir School er det fremste reisemålet for folk som ønsker å lære og mestre programmeringsspråket Elixir."
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:98
 msgid "Elixir and the BEAM virtual machine pack a serious punch when it comes to features. With over 35 years of experience the Erlang runtime system has proven itself time and time again as solid platform for distributed, high-available systems."
-msgstr ""
+msgstr "Elixir og den virtuelle maskinvaren BEAM pakker en real skuddsalve av funksjoner. Med over 35 års erfaring har Erlang bevist gang på gang at det er en solid plattform for distribuerte, høytilgjengelige systemer."
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:8
 msgid "Elixir is a wonderful language but don't take our word for it. Let's look at some of the reasons you and your organization should adopt Elixir."
-msgstr ""
+msgstr "Elixir er et fantastisk språk, men ikke ta vårt ord på det. La oss se på noen av grunnene til at du og din bedrift burde velge Elixir."
 
 #, elixir-format
 #: lib/school_house_web/templates/page/_newsletter.html.heex:14
 msgid "Email address"
-msgstr ""
+msgstr "Epost-adresse"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_lesson_menu.html.heex:312
 msgid "Embedded Elixir (EEx)"
-msgstr ""
+msgstr "Embedded Elixir (EEx)"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/_newsletter.html.heex:15
 msgid "Enter your email"
-msgstr ""
+msgstr "Fyll ut din epost-adresse"
 
 #, elixir-format
 #: lib/school_house_web/templates/lesson/_storage.html.heex:8
 msgid "Explore how interact with the BEAM's built in data storage, Redis, and others."
-msgstr ""
+msgstr "Utforsk hvordan du kan interagere med BEAMs innebygde dataoppbevaring, Redis og andre løsninger."
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:133
 msgid "Extensible"
-msgstr ""
+msgstr "Utvidbar"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:121
 msgid "Fault Tolerant"
-msgstr ""
+msgstr "Feil-tolerant"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/index.html.heex:90
 #: lib/school_house_web/templates/page/why.html.heex:97
 msgid "Feature Packed"
-msgstr ""
+msgstr "Funksjonsrik"
 
 #, elixir-format
 #: lib/school_house_web/live/conferences_live.html.heex:17
 msgid "Filter"
-msgstr ""
+msgstr "Filtrer"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:42
 msgid "Focus on Functions"
-msgstr ""
+msgstr "Fokus på funksjoner"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:237
 msgid "Forum"
-msgstr ""
+msgstr "Forum"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/index.html.heex:71
 #: lib/school_house_web/templates/page/why.html.heex:72
 msgid "Functional Programming"
-msgstr ""
+msgstr "Funksjonell programmering"
 
 #, elixir-format
 #: lib/school_house_web/controllers/page_controller.ex:27
 #: lib/school_house_web/templates/layout/_footer.html.heex:116 lib/school_house_web/templates/layout/_header.html.heex:22
 #: lib/school_house_web/templates/page/get_involved.html.heex:5
 msgid "Get Involved"
-msgstr ""
+msgstr "Bli med"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_footer.html.heex:37
 msgid "Getting Started"
-msgstr ""
+msgstr "Kom i gang"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:267
 msgid "Hashtags"
-msgstr ""
+msgstr "Hashtagger"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/get_involved.html.heex:56
 msgid "Have a topic related to Elixir that you are knowledgeable about and want to share? Write a blog post and it could be featured on the Elixir School post feed."
-msgstr ""
+msgstr "Har du et emne relatert til Elixir som du kan mye om og ønsker å dele? Skriv en bloggpost og du kan kan få den publisert på vår blogg."
 
 #, elixir-format
 #: lib/school_house_web/controllers/page_controller.ex:7
 msgid "Home"
-msgstr ""
+msgstr "Hjem"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:25
 msgid "Immutability"
-msgstr ""
+msgstr "Immutabilitet"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/get_involved.html.heex:21
 msgid "Improve the Website"
-msgstr ""
+msgstr "Forbedre nettsiden"
 
 #, elixir-format
 #: lib/school_house_web/templates/lesson/_ecto.html.heex:8
 msgid "Interacting with data is a part of most applications. These lessons explore the Ecto library and how to leverage it for our database interactions."
-msgstr ""
+msgstr "Interaksjon med data er noe de fleste applikasjoner gjør. Disse leksjonene utforsker pakken Ecto og hvordan du kan bruke det til dine database-interaksjoner."
 
 #, elixir-format
 #: lib/school_house_web/templates/page/_newsletter.html.heex:9
 msgid "Join the Elixir School newsletter to keep up with the latest lessons, blog posts, and opportunities within the community."
-msgstr ""
+msgstr "Meld deg på vårt nyhetsbrev for å holde deg oppdatert på de siste leksjonene, bloggpostene og mulighetene i fellesskapet."
 
 #, elixir-format
 #: lib/school_house_web/templates/page/index.html.heex:173
 msgid "Languages"
-msgstr ""
+msgstr "Språk"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/index.html.heex:76
 #: lib/school_house_web/templates/page/index.html.heex:95 lib/school_house_web/templates/page/index.html.heex:115
 msgid "Learn More"
-msgstr ""
+msgstr "Lær mer"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_footer.html.heex:53
@@ -605,360 +606,360 @@ msgstr ""
 #: lib/school_house_web/templates/lesson/_misc.html.heex:5 lib/school_house_web/templates/lesson/_storage.html.heex:5
 #: lib/school_house_web/templates/lesson/_testing.html.heex:5
 msgid "Lessons"
-msgstr ""
+msgstr "Leksjoner"
 
 #, elixir-format
 #: lib/school_house_web/templates/lesson/_basics.html.heex:8
 msgid "Lessons covering the foundational topics. New to Elixir? This is the place to start."
-msgstr ""
+msgstr "Leksjoner som dekker grunnleggende emner. Ny til Elixir? Her er stedet å starte."
 
 #, elixir-format
 #: lib/school_house_web/templates/page/get_involved.html.heex:40
 msgid "Lessons on Elixir School are translated into 25 different languages! If there is a lesson missing a translation that you can provide, translate it and create a pull request."
-msgstr ""
+msgstr "Leksjonene på Elixir School er oversatt til 25 forskjellige språk! Hvis det er en leksjon som mangler en oversettelse i et språk du kan, kan du gjerne oversette den og opprette en pull request."
 
 #, elixir-format
 #: lib/school_house_web/live/conferences_live.html.heex:35
 msgid "Location"
-msgstr ""
+msgstr "Sted"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:252
 msgid "Meetups"
-msgstr ""
+msgstr "Meetups"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:285
 msgid "More to come..."
-msgstr ""
+msgstr "Mer kommer..."
 
 #, elixir-format
 #: lib/school_house_web/live/conferences_live.html.heex:32
 msgid "Name"
-msgstr ""
+msgstr "Navn"
 
 #, elixir-format
 #: lib/school_house_web/templates/lesson/_pagination.html.heex:31
 msgid "Next Lesson"
-msgstr ""
+msgstr "Neste leksjon"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/_newsletter.html.heex:17
 msgid "Notify me"
-msgstr ""
+msgstr "Varsle meg"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/index.html.heex:195
 msgid "On Hex"
-msgstr ""
+msgstr "Om Hex"
 
 #, elixir-format
 #: lib/school_house_web/live/conferences_live.html.heex:20
 msgid "Online"
-msgstr ""
+msgstr "Online"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/index.html.heex:195
 msgid "Packages"
-msgstr ""
+msgstr "Pakker"
 
 #, elixir-format
 #: lib/school_house_web/views/error_view.ex:7
 msgid "Page not found"
-msgstr ""
+msgstr "Siden ble ikke funnet"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:169
 msgid "Performant"
-msgstr ""
+msgstr "Effektiv"
 
 #, elixir-format
 #: lib/school_house_web/controllers/page_controller.ex:11
 #: lib/school_house_web/templates/layout/_footer.html.heex:44 lib/school_house_web/templates/page/index.html.heex:162
 msgid "Podcasts"
-msgstr ""
+msgstr "Podcasts"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:240
 msgid "Prefer the forum format for your questions? No problem! Head over to"
-msgstr ""
+msgstr "Foretrekker du å stille dine spørsmål i et forum? Ikke noe stress! Gå til"
 
 #, elixir-format
 #: lib/school_house_web/templates/post/post.html.heex:12
 msgid "Presents"
-msgstr ""
+msgstr "Presenterer"
 
 #, elixir-format
 #: lib/school_house_web/templates/lesson/_pagination.html.heex:12
 msgid "Previous Lesson"
-msgstr ""
+msgstr "Forrige leksjon"
 
 #, elixir-format
 #: lib/school_house_web/controllers/page_controller.ex:15
 #: lib/school_house_web/templates/page/_newsletter.html.heex:23
 msgid "Privacy Policy"
-msgstr ""
+msgstr "Personvern"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:45
 msgid "Problems are decomposed into simple functions with an emphasis on no side-effects."
-msgstr ""
+msgstr "Problemer brytes ned til enkle funksjoner med fokus på at de ikke har noen sideeffekter."
 
 #, elixir-format
 #: lib/school_house_web/templates/lesson/_data_processing.html.heex:8
 msgid "Processing large amount of data concurrently comes easy to Elixir. We'll explore how to leverage libraries to make this task even easier."
-msgstr ""
+msgstr "Å prosessere store mengder data samtidig er enkelt i Elixir. Vi kommer til å utforske hvordan vi kan bruke biblioteker for å gjøre denne oppgaven enda enklere."
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_footer.html.heex:112
 msgid "Project"
-msgstr ""
+msgstr "Prosjekt"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:209
 msgid "Request your invite today!"
-msgstr ""
+msgstr "Be om din invitasjon i dag!"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_footer.html.heex:105
 msgid "Reviews"
-msgstr ""
+msgstr "Anmeldelser"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/index.html.heex:154
 #: lib/school_house_web/templates/page/index.html.heex:165 lib/school_house_web/templates/page/index.html.heex:176
 #: lib/school_house_web/templates/page/index.html.heex:187 lib/school_house_web/templates/page/index.html.heex:198
 msgid "See Them Here"
-msgstr ""
+msgstr "Se dem her"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/get_involved.html.heex:26
 msgid "See something you think should be improved? Feel free to open an issue or create a pull request with the change."
-msgstr ""
+msgstr "Ser du noe som du mener burde bli forbedret? Vi setter veldig pris på om du åpner en sak eller oppretter en pull request med forslag til endring."
 
 #, elixir-format
 #: lib/school_house_web/templates/page/_newsletter.html.heex:6
 msgid "Sign up for our newsletter"
-msgstr ""
+msgstr "Meld deg på vårt nyhetsbrev"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:47
 msgid "Since functions are first class citizens in Functional Programming we're able to easily re-use our functions throughout our applications."
-msgstr ""
+msgstr "Siden funksjoner er fundamentet til funksjonell programmering, kan vi enkelt gjenbruke funksjonene våre i hele applikasjonen."
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:205
 msgid "Slack"
-msgstr ""
+msgstr "Slack"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/index.html.heex:146
 msgid "Still not convinced? Here are some numbers that demonstrate Elixir's growth and reach."
-msgstr ""
+msgstr "Fortsatt ikke overbevist? Her er noen tall som viser Elixirs vekst og rekkevide."
 
 #, elixir-format
 #: lib/school_house_web/templates/lesson/lesson.html.heex:11
 msgid "Table of Contents"
-msgstr ""
+msgstr "Innholdsfortegnelse"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/get_involved.html.heex:25
 msgid "Take a look at the"
-msgstr ""
+msgstr "Ta en titt på"
 
 #, elixir-format
 #: lib/school_house_web/templates/lesson/_advanced.html.heex:8
 msgid "Taking our knowledge to the next level, these lessons get cover the advanced topics of Elixir and the BEAM."
-msgstr ""
+msgstr "La oss ta kunnskapen vår til det neste nivået. Disse leksjonene dekker avanserte emner innen Elixir og BEAM."
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:208
 msgid "The Elixir Slack is a popular destination for many in the community."
-msgstr ""
+msgstr "Elixir-slacken er et populært knytepunkt for mange i Elixir-fellesskapet."
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:195
 msgid "The community and ecosystem that have grown up with the language remain one of the alluring parts of Elixir."
-msgstr ""
+msgstr "Fellesskapet og økosystemet som har vokst opp med og rundt språket, er en av de mest tiltalende aspektene av Elixir."
 
 #, elixir-format
 #: lib/school_house_web/templates/lesson/_testing.html.heex:8
 msgid "The first step to writing fault tolerant and scalable code is writing bug free code. In these lessons we explore how best to test our Elixir code."
-msgstr ""
+msgstr "Første steg for å skrive feil-tolerant og skalerbar kode, er å skrive feilfri kode. I disse leksjonene utforsker vi hvordan vi tester Elixir-koden vår på best mulig måte."
 
 #, elixir-format
 #: lib/school_house_web/views/error_view.ex:8
 msgid "The page you're looking for seems to be missing."
-msgstr ""
+msgstr "Vi kunne ikke finne siden du så etter."
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_footer.html.heex:13
 msgid "The premier destination for learning and mastering Elixir"
-msgstr ""
+msgstr "Det beste stedet for å lære og mestre Elixir"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:63
 msgid "The very nature of functional programming, small functions with no side-effects, makes testing easy."
-msgstr ""
+msgstr "Fundamentet til funksjonell programmering, nemlig små funksjoner uten side-effekter, gjør testing enkelt."
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:46
 msgid "These \"pure functions\" always produce the same results for a given input and change nothing."
-msgstr ""
+msgstr "Disse \"rene funksjonene\" produserer alltid de samme resultatene for en gitt input, uten å endre noe."
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:30
 msgid "This has the added benefit of improving support for concurrency and thus scalability of systems."
-msgstr ""
+msgstr "Dette har også en ekstra positiv effekt av å forbedre støtten for concurrency og dermed skalerbarhet av systemer."
 
 #, elixir-format
 #: lib/school_house_web/templates/page/get_involved.html.heex:57
 msgid "This is a great way to contribute and get visibility for your post! Steps for submitting a post are available on"
-msgstr ""
+msgstr "Dette er en flott måte å bidra på, og få synlighet for ditt innlegget! Stegene for å sende inn et innlegg er tilgjengelig på"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/index.html.heex:12
 msgid "Through the hard work of volunteers Elixir School has been translated to many languages. Some of these translations include: "
-msgstr ""
+msgstr "Gjennom det harde arbeidet til frivillige, har Elixir School blitt oversatt til mange språk. Noen av disse oversettelsene inkluderer:"
 
 #, elixir-format
 #: lib/school_house_web/templates/layout/_footer.html.heex:101
 msgid "Today I Learned (TIL)"
-msgstr ""
+msgstr "I dag lærte jeg (TIL)"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/get_involved.html.heex:37
 msgid "Translate Lessons"
-msgstr ""
+msgstr "Oversett leksjoner"
 
 #, elixir-format
 #: lib/school_house_web/templates/error/translation_missing.html.heex:4
 msgid "Translation unavailable"
-msgstr ""
+msgstr "Oversettelse mangler"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/index.html.heex:173
 msgid "Translations"
-msgstr ""
+msgstr "Oversettelser"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/index.html.heex:184
 msgid "Using Elixir"
-msgstr ""
+msgstr "Bruke Elixir"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/index.html.heex:110
 #: lib/school_house_web/templates/page/why.html.heex:194
 msgid "Vibrant Ecosystem"
-msgstr ""
+msgstr "Levende økosystem"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/index.html.heex:268
 msgid "Want to learn more?"
-msgstr ""
+msgstr "Lyst til å lære mer?"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/_newsletter.html.heex:21
 msgid "We care about the protection of your data. Read our"
-msgstr ""
+msgstr "Vi bryr oss om beskyttelsen av dine data. Les vår"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/index.html.heex:270
 msgid "We have articles spanning several topics"
-msgstr ""
+msgstr "Vi har artikler som dekker flere emner"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/index.html.heex:34
 msgid "We welcome and encourage you to join us in continuing to make Elixir School great by getting involved at elixirschool/elixirschool!"
-msgstr ""
+msgstr "Vi ønsker og oppfordrer deg til å bli med oss i å fortsette å gjøre Elixir School enda bedre ved å bli involvert på elixirschool/elixirschool!"
 
 #, elixir-format
 #: lib/school_house_web/templates/error/translation_missing.html.heex:6
 msgid "We're sorry, the resource you're looking for has not been translated yet."
-msgstr ""
+msgstr "Vi beklager, ressursen du leter etter har ikke blitt oversatt ennå."
 
 #, elixir-format
 #: lib/school_house_web/templates/page/index.html.heex:5
 msgid "Welcome to Elixir School!"
-msgstr ""
+msgstr "Velkommen til Elixir School!"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/index.html.heex:9
 msgid "Whether you’re a seasoned veteran or this is your first time, you’ll find what you need in lessons and auxiliary resources."
-msgstr ""
+msgstr "Enten du er en erfaren alkymist eller dette er første gangen, vil du finne det du trenger blant våre leksjoner og hjelpemidler."
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:74
 msgid "While its roots are in lambda calculus, functional programming can be fun, easy, and approachable for everyone! By focusing on breaking problems down into simple, side-effect free, functions we can ensure fewer bugs, better test coverage, while incrementally building our solutions through the composition of well tested functions."
-msgstr ""
+msgstr "Med røtter i lambda-kalkulus, kan funksjonell programmering være morsomt, enkelt og tilgjengelig for alle! Ved å fokusere på å bryte opp problemer inn i enkle funksjoner, fri for side-effekter, kan vi sikre at vi skriver færre feil, får bedre testdekning, mens vi gradvis bygger løsningene våre gjennom sammensetning av godt testede funksjoner."
 
 #, elixir-format
 #: lib/school_house_web/controllers/page_controller.ex:23
 msgid "Why Choose Elixir?"
-msgstr ""
+msgstr "Hvorfor velge Elixir?"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/index.html.heex:173
 msgid "With Lesson"
-msgstr ""
+msgstr "Med leksjon"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/index.html.heex:112
 msgid "With dozens of conferences, hundreds of meetups, Slack, IRC, Discord, and multiple active hashtags."
-msgstr ""
+msgstr "Med titalls konferanser, hundrevis av meetups, Slack, IRC, Discord, og flere aktive hashtagger."
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:255
 msgid "With over 150 meetups, you're sure to find local Elixir enthusiasts. Check out"
-msgstr ""
+msgstr "Med over 150 meetups, finner du lokale Elixir-entusiaster. Se på"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/index.html.heex:30
 #: lib/school_house_web/templates/page/why.html.heex:270
 msgid "and"
-msgstr ""
+msgstr "og"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/get_involved.html.heex:42
 msgid "are available on"
-msgstr ""
+msgstr "er tilgjengelig på"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:255
 msgid "for more."
-msgstr ""
+msgstr "for mer."
 
 #, elixir-format
 #: lib/school_house_web/templates/page/get_involved.html.heex:25
 msgid "issues"
-msgstr ""
+msgstr "saker"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:270
 msgid "on Twitter."
-msgstr ""
+msgstr "på Twitter."
 
 #, elixir-format
 #: lib/school_house_web/templates/page/get_involved.html.heex:25
 msgid "on the repository to find a task that interests you. Create a pull request when your change is ready and after review it will be merged into the codebase!"
-msgstr ""
+msgstr "på repository for å finne en oppgave som interesserer deg. Opprett en pull request når endringen er klar, og etter gjennomgang vil den bli slått sammen med kodebasen!"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/why.html.heex:240
 msgid "to join the conversation."
-msgstr ""
+msgstr "for å bli med i samtalen."
 
 #, elixir-format
 #: lib/school_house_web/templates/post/index.html.heex:5
 msgid "Recent Posts"
-msgstr ""
+msgstr "Siste innlegg"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/index.html.heex:162
 msgid "(& Counting)"
-msgstr ""
+msgstr "(& Teller)"
 
 #, elixir-format
 #: lib/school_house_web/templates/page/index.html.heex:273
 msgid "Visit the Blog"
-msgstr ""
+msgstr "Besøk bloggen"


### PR DESCRIPTION
Upon initial page load, users with MacBooks (and other devices that support dark mode as a system setting), the mode is set to light. This has a tendency to blast my retinas with unexpected blue light at 1AM on a Tuesday night.

The browser exposes a flag that lets us known if the user has dark mode enabled on their device, namely `prefers-color-scheme: dark`. I think this is a pretty cool feature, and thought it'd be great to use this on elixir school. 😄 

Also found an excuse to sneak in a typo fix from a previous PR that slipped through the gaps. 🙇 
