### PR TITLE
fix: edit this lesson on github links

### DIFF
--- a/lib/school_house_web/templates/lesson/lesson.html.heex
+++ b/lib/school_house_web/templates/lesson/lesson.html.heex
@@ -17,7 +17,7 @@
 
   <blockquote class="edit-lesson dark:text-primary-dark">
     <%= gettext("Caught a mistake or want to contribute to the lesson?")%>
-    <a href={"https://github.com/elixirschool/elixirschool/edit/master/lessons/#{@lesson.locale}/#{@lesson.section}/#{@lesson.name}.md"} target="_blank" rel="noopener">
+    <a href={"https://github.com/elixirschool/elixirschool/edit/main/lessons/#{@lesson.locale}/#{@lesson.section}/#{@lesson.name}.md"} target="_blank" rel="noopener">
       <%= gettext("Edit this lesson on GitHub!")%>
     </a>
   </blockquote>


### PR DESCRIPTION
Noticed when trying to edit the `bypass.md` in `elixirschool/elixirschool` from the GitHub UI, the stale `master` ref made life hard. This should fix that.