### PR TITLE
Added some spacing for underline decorations

### DIFF
--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -116,6 +116,8 @@ module.exports = {
                                 ),
                                 color: colors.white,
                             },
+			    textUnderlinePosition: 'under',
+			    textUnderlineOffset: '2px',
                         },
                         'code::before': {
                             content: '""',


### PR DESCRIPTION
Added some spacing between link text and its underline decoration.
Left side showing current style, right is the new style:

![image](https://github.com/elixirschool/school_house/assets/5412540/a1135ab5-51b9-47fc-a073-0ab4694e1032)
