### PR TITLE
Lesson Checkpoint Feature: Display Last Read Point on Homepage

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -40,5 +40,6 @@ liveSocket.connect()
 // >> liveSocket.enableLatencySim(1000)
 window.liveSocket = liveSocket
 
+import "./pickup"
 import "./dark-mode"
 import "./menu-toggle"

--- a/assets/js/pickup.js
+++ b/assets/js/pickup.js
@@ -1,0 +1,30 @@
+const msg = document.querySelector("#pick-up")
+const btn = msg.querySelector("a")
+const closeBtn = msg.querySelector("button")
+
+const pickupFrom = JSON.parse(localStorage.getItem("pick-up"))
+
+const urlParams = new URLSearchParams(window.location.search);
+
+closeBtn.onclick = () => {
+  msg.classList.add("hidden")
+}
+
+function updateMessage() {
+  if (pickupFrom && !window.location.pathname.includes("/lessons")) {
+    msg.classList.remove("hidden")
+    btn.href = pickupFrom.from+"?pickup=true"
+  } else if (pickupFrom && window.location.pathname === pickupFrom.from && urlParams.get("pickup") == "true") {
+    window.scrollTo(0, pickupFrom.scroll)
+  } else {
+    localStorage.setItem("pick-up", JSON.stringify({ from: window.location.pathname, scroll: window.scrollY }))
+  }
+}
+
+window.onload = updateMessage
+
+if (window.location.pathname.includes("/lessons")) {
+  window.addEventListener("scroll", () => {
+    localStorage.setItem("pick-up", JSON.stringify({ from: window.location.pathname, scroll: window.scrollY }))
+  })
+}

--- a/lib/school_house_web/templates/layout/root.html.heex
+++ b/lib/school_house_web/templates/layout/root.html.heex
@@ -15,6 +15,17 @@
     <link rel="icon" href="/favicon.ico" />
   </head>
   <body class="preload dark:bg-body-dark overflow-x-hidden">
+    <div id="pick-up" class="hidden w-full md:text-md text-sm sticky text-white bg-purple font-semibold py-3 text-center">
+      Want to pick up from where you left of? 
+      <div class="md:hidden leading-[5px]"><br/></div>
+      <a class="cursor-pointer ml-2 mt-2 md:mt-0 font-normal px-3 py-1 text-xs md:text-sm rounded-md dark:text-white text-black bg-nav dark:bg-nav-dark">
+        Take me there 
+        <svg class="inline-block" xmlns="http://www.w3.org/2000/svg" width="1.3em" viewBox="0 0 24 24"><path fill="currentColor" d="M12.6 12L8.7 8.1q-.275-.275-.275-.7t.275-.7q.275-.275.7-.275t.7.275l4.6 4.6q.15.15.213.325t.062.375q0 .2-.063.375t-.212.325l-4.6 4.6q-.275.275-.7.275t-.7-.275q-.275-.275-.275-.7t.275-.7l3.9-3.9Z"/></svg>
+      </a>
+      <button class="absolute right-2 top-[50%] -translate-y-[50%]">
+        <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><path fill="currentColor" d="m17.705 7.705l-1.41-1.41L12 10.59L7.705 6.295l-1.41 1.41L10.59 12l-4.295 4.295l1.41 1.41L12 13.41l4.295 4.295l1.41-1.41L13.41 12l4.295-4.295z"/></svg>
+      </button>
+    </div>
     <%= render "_header.html", conn: @conn %>
     <%= @inner_content %>
     <%= render "_footer.html", conn: @conn %>


### PR DESCRIPTION
I've implemented a new feature in a file called `pickup.js` that saves the last point in the lessons that a user has read. This feature is designed to enhance the user experience by allowing them to easily pick up where they left off in their learning journey.

It saves the pathname and the scrolled value of the last visited lesson and continues at that point 

# Changes Made
- Added a function in pickup.js to store the last read lesson point in local storage.
- Modified the homepage to display a message that guides users to continue their lessons from the last read point.

# Motivation
I found it difficult to remember where I left off in a series of lessons. So I thought I should contribute

---
Here is a gif demonstrating how it works

![](https://us-east-1.tixte.net/uploads/kekda.wants.solutions/chrome_vmbVNNcouC.gif)