### PR TITLE
Fix the casing on GitHub

### DIFF
--- a/lib/school_house_web/templates/page/get_involved.html.heex
+++ b/lib/school_house_web/templates/page/get_involved.html.heex
@@ -21,7 +21,7 @@
           <%= gettext("Improve the Website") %>
         </h3>
         <div class="mt-2 text-base text-light dark:text-light-dark">
-          <%= gettext("Elixir School is an open source project, with code hosted on") %> <a target="_blank" href="https://github.com/elixirschool/school_house" class="font-bold text-purple dark:text-purple-dark">Github</a>.
+          <%= gettext("Elixir School is an open source project, with code hosted on") %> <a target="_blank" href="https://github.com/elixirschool/school_house" class="font-bold text-purple dark:text-purple-dark">GitHub</a>.
           <%= gettext("Take a look at the") %> <a target="_blank" href="https://github.com/elixirschool/school_house/issues" class="font-bold text-purple dark:text-purple-dark"><%= gettext("issues") %></a> <%= gettext("on the repository to find a task that interests you. Create a pull request when your change is ready and after review it will be merged into the codebase!") %>
           <%= gettext("See something you think should be improved? Feel free to open an issue or create a pull request with the change.") %>
         </div>
@@ -39,7 +39,7 @@
         <div class="mt-2 text-base text-light dark:text-light-dark">
           <%= gettext("Lessons on Elixir School are translated into 25 different languages! If there is a lesson missing a translation that you can provide, translate it and create a pull request.") %>
           <%= gettext("As you read lessons, if you see an opportunity for improvement go ahead and create a pull request with the change, the next reader will thank you. Steps for translating a lesson") %>
-          <%= gettext("are available on") %> <a target="_blank" href="https://github.com/elixirschool/elixirschool#translating-a-lesson" class="font-bold text-purple dark:text-purple-dark">Github</a>.
+          <%= gettext("are available on") %> <a target="_blank" href="https://github.com/elixirschool/elixirschool#translating-a-lesson" class="font-bold text-purple dark:text-purple-dark">GitHub</a>.
         </div>
       </div>
     </div>
@@ -55,7 +55,7 @@
         <div class="mt-2 text-base text-light dark:text-light-dark">
           <%= gettext("Have a topic related to Elixir that you are knowledgeable about and want to share? Write a blog post and it could be featured on the Elixir School post feed.") %>
           <%= gettext("This is a great way to contribute and get visibility for your post! Steps for submitting a post are available on") %>
-          <a target="_blank" href="https://github.com/elixirschool/elixirschool#posting-an-article" class="font-bold text-purple dark:text-purple-dark">Github</a>.
+          <a target="_blank" href="https://github.com/elixirschool/elixirschool#posting-an-article" class="font-bold text-purple dark:text-purple-dark">GitHub</a>.
         </div>
       </div>
     </div>

--- a/priv/gettext/ko/LC_MESSAGES/default.po
+++ b/priv/gettext/ko/LC_MESSAGES/default.po
@@ -434,7 +434,7 @@ msgstr "손쉬운 테스트"
 #, elixir-format
 #: lib/school_house_web/templates/lesson/lesson.html.heex:21
 msgid "Edit this lesson on GitHub!"
-msgstr "Github에서 이 강의를 수정해보세요!"
+msgstr "GitHub에서 이 강의를 수정해보세요!"
 
 #, elixir-format
 #: lib/school_house_web/live/conferences_live.html.heex:5


### PR DESCRIPTION
👋 hello from a long-time admirer and :octocat: staff.

This PR fixes the company name from `Github` to `GitHub` 🙇 

thanks for all you do here 💖