### PR TITLE
chore: use ghcr for docker image building and publishing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
             latest=auto
           github-token: ${{ secrets.GITHUB_TOKEN }}
           images: |
-            ghcr.io/${{ context.repo.owner }}/${{ context.repo.repo }}
+            ghcr.io/${{ github.repository }}
           tags: |
             type=sha
             type=semver,pattern={{version}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,10 @@ jobs:
       image: ${{ steps.outputs.outputs.image }}
       tag: ${{ steps.outputs.outputs.tag }}
 
+    permissions:
+      contents: read
+      packages: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -39,6 +43,13 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Login (GHCR)
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: build
         name: Build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
             latest=auto
           github-token: ${{ secrets.GITHUB_TOKEN }}
           images: |
-            ghcr.io/${context.repo.owner}/${context.repo.repo}
+            ghcr.io/${{ context.repo.owner }}/${{ context.repo.repo }}
           tags: |
             type=sha
             type=semver,pattern={{version}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,13 +8,79 @@ on:
       - main
 
 jobs:
-  Deploy:
+  Docker:
     if: ${{ github.repository_owner == 'elixirschool' }}
     runs-on: ubuntu-latest
 
+    outputs:
+      image: ${{ steps.outputs.outputs.image }}
+      tag: ${{ steps.outputs.outputs.tag }}
+
     steps:
-      - uses: actions/checkout@v3
-      - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy --local-only
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - id: metadata
+        name: Get Metadata
+        uses: docker/metadata-action@v5
+        with:
+          flavor: |
+            latest=auto
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          images: |
+            ghcr.io/${context.repo.owner}/${context.repo.repo}
+          tags: |
+            type=sha
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=ref,event=branch
+            type=ref,event=pr
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - id: build
+        name: Build
+        uses: docker/build-push-action@v6
+        with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          labels: ${{ steps.metadata.outputs.labels }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+
+      - id: outputs
+        name: Get Outputs
+        uses: actions/github-script@v7
+        env:
+          BUILD_OUTPUT: ${{ steps.metadata.outputs.json }}
+        with:
+          script: |
+            const metadata = JSON.parse(process.env.BUILD_OUTPUT)
+            const shaUrl = metadata.tags.find((t) => t.includes(':sha-'))
+
+            if (shaUrl == null) {
+              core.error('Unable to find sha tag of image')
+            } else {
+              const [image, tag] = shaUrl.split(':')
+              core.setOutput('image', image)
+              core.setOutput('tag', tag)
+            }
+
+  Deploy:
+    if: ${{ github.repository_owner == 'elixirschool' }}
+    runs-on: ubuntu-latest
+    needs: [Docker]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install (flyctl)
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - run: flyctl deploy --yes --image "${{ needs.Docker.outputs.image }}:${{ needs.Docker.outputs.tag }}"
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@
 #   - https://pkgs.org/ - resource for finding needed packages
 #   - Ex: hexpm/elixir:1.13.4-erlang-25.0.4-debian-bullseye-20220801-slim
 #
-ARG ELIXIR_VERSION=1.14.1
+ARG ELIXIR_VERSION=1.15.8
 ARG OTP_VERSION=25.0.4
-ARG DEBIAN_VERSION=bullseye-20220801-slim
+ARG DEBIAN_VERSION=bullseye-20240722-slim
 
 ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
 ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"
@@ -83,7 +83,7 @@ RUN mix release
 FROM ${RUNNER_IMAGE}
 
 RUN apt-get update -y && apt-get install -y libstdc++6 openssl libncurses5 locales \
-  && apt-get clean && rm -f /var/lib/apt/lists/*_*
+    && apt-get clean && rm -f /var/lib/apt/lists/*_*
 
 # Set the locale
 RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen


### PR DESCRIPTION
This uses the github container registry for publishing the image fly pulls. This should have the same result as doing what we are doing now, but with better cache and the ability to pull the images down locally to test.