### PR TITLE
fixes HTML error, p is not allowed as a child of span

### DIFF
--- a/lib/school_house_web/templates/post/_post_preview.html.heex
+++ b/lib/school_house_web/templates/post/_post_preview.html.heex
@@ -9,8 +9,8 @@
     <% end %>
   </div>
   <%= link(to: Routes.post_path(@conn, :show, @post.slug), class: "block mt-4 prose dark:prose-dark") do %>
-    <span class="text-xl font-semibold"><%= raw @post.title %></span>
-    <span class="mt-3 text-base"><%= raw @post.excerpt %></span>
+    <div class="text-xl font-semibold"><%= raw @post.title %></div>
+    <div class="mt-3 text-base"><%= raw @post.excerpt %></div>
   <% end %>
   <div class="flex items-center mt-6">
     <div class="flex-shrink-0">


### PR DESCRIPTION
As reported in the [latest Rocket Validator report](https://rocketvalidator.com/s/4f457baa-b5c6-4fbf-a4c0-0ac45f44d423/i/166559094), post previews had an HTML issue as some `<p>` tags were inside `<span>` elements, which is not allowed.

<img width="966" height="885" alt="Captura de pantalla 2025-08-20 a las 19 17 20" src="https://github.com/user-attachments/assets/63d14d5d-6501-465e-8ca6-ac6688eae278" />


Changing the `<span>` by `<div>` fixes the issue by now, later we should think of a more semantic approach for this, probably.