### PR TITLE
fixes HTML issue for h1 containing p

### DIFF
--- a/lib/school_house_web/templates/post/post.html.heex
+++ b/lib/school_house_web/templates/post/post.html.heex
@@ -15,7 +15,7 @@
     </div>
 
     <div class="pt-6 text-center">
-      <h1 class="text-2xl leading-8 font-extrabold tracking-tight sm:text-2xl prose dark:prose-dark"><%= raw @post.title %></h1>
+      <h1 class="text-2xl leading-8 font-extrabold tracking-tight sm:text-2xl prose dark:prose-dark"><%= @post.title |> strip_p_tags() |> raw() %></h1>
     </div>
 
     <div class="py-2 text-center">

--- a/lib/school_house_web/views/html_helpers.ex
+++ b/lib/school_house_web/views/html_helpers.ex
@@ -99,4 +99,19 @@ defmodule SchoolHouseWeb.HtmlHelpers do
   def translation_status_css_class(%{status: :minor}), do: "bg-yellow-400"
   def translation_status_css_class(%{status: :patch}), do: "bg-yellow-200"
   def translation_status_css_class(_line), do: "bg-white"
+
+  @doc """
+  Removes all <p> and </p> tags from the given string, inserting newline if needed.
+
+  This is useful to avoid nesting <p> tags inside elements that don't allow them like headings or span,
+  for example in the blog posts titles.
+  """
+  def strip_p_tags(str) when is_binary(str) do
+    str
+    |> String.replace("<p>", "")
+    |> String.replace("</p>", "\n")
+    |> String.trim()
+  end
+
+  def strip_p_tags(str), do: str
 end

--- a/test/school_house_web/views/html_helpers_test.exs
+++ b/test/school_house_web/views/html_helpers_test.exs
@@ -69,4 +69,14 @@ defmodule SchoolHouseWeb.HtmlHelpersTest do
       assert 1 < length(locales)
     end
   end
+
+  describe "strip_p_tags" do
+    test "removes <p> and </p> tags from string" do
+      assert HtmlHelpers.strip_p_tags("<p>some content</p>") == "some content"
+    end
+
+    test "converts </p> tags to newline" do
+      assert HtmlHelpers.strip_p_tags("<p>one</p><p>two</p>") == "one\ntwo"
+    end
+  end
 end


### PR DESCRIPTION
As reported in the [latest Rocket Validator report](https://rocketvalidator.com/s/4f457baa-b5c6-4fbf-a4c0-0ac45f44d423/i/166559092), post titles had `<p>` tags inside `<h1>` tags, which is not allowed.

<img width="1166" height="862" alt="Captura de pantalla 2025-08-20 a las 19 40 37" src="https://github.com/user-attachments/assets/9bacfead-9d4a-4b69-a9c7-c6f1403383bb" />

As the post titles come from NimblePublisher they contain `<p>` tags, so I added a quick helper to strip those p tags where needed.

Maybe we should review if we instead want the post titles to be simple strings, without HTML tags.

Update: we need to keep tags in titles as long as we use code blocks in the titles, as in https://github.com/elixirschool/elixirschool/blob/main/posts/2019-02-06-til-send-after.md?plain=1#L6